### PR TITLE
fix: fix words.chunks not being recognized

### DIFF
--- a/administrative-sdk.js
+++ b/administrative-sdk.js
@@ -1865,7 +1865,7 @@ class Sdk {
     var words = [];
     inWords.forEach(function(word) {
       var chunks = [];
-      word.chunks.forEach(function(chunk) {
+      word.forEach(function(chunk) {
         var phonemes = [];
         // Phonemes are only provided on detailed analysis.
         chunk.phonemes = chunk.phonemes || [];


### PR DESCRIPTION
tests were failing because words.chunks.forEach was undefined
because 'words' did not contain 'chunks'.