### PR TITLE
fix(streaming): fix id set to null early

### DIFF
--- a/administrative-sdk/choice-recognition/choice-recognition-controller.js
+++ b/administrative-sdk/choice-recognition/choice-recognition-controller.js
@@ -114,6 +114,7 @@ module.exports = class ChoiceRecognitionController {
           challenge.id, data.studentId, data.id,
           new Date(data.created), new Date(data.updated),
           self.connection.addAccessToken(data.audioUrl), data.recognised);
+        recognition.recognitionId = self.connection._recognitionId;
         resolve(recognition);
       }
 
@@ -206,13 +207,14 @@ module.exports = class ChoiceRecognitionController {
               res.kwargs.recognition.message = 'Unhandled error';
             }
             _ecb(res.kwargs.analysis);
-          }
-        );
+          })
+          .then(() => {
+            // This session is over.
+            self.connection._recognitionId = null;
+          });
 
         recorder.removeEventListener('recorded', recordedCb);
         recorder.removeEventListener('dataavailable', dataavailableCb);
-        // This session is over.
-        self.connection._recognitionId = null;
       }
       recorder.addEventListener('recorded', recordedCb);
     });

--- a/administrative-sdk/pronunciation-analysis/pronunciation-analysis-controller.js
+++ b/administrative-sdk/pronunciation-analysis/pronunciation-analysis-controller.js
@@ -221,9 +221,11 @@ module.exports = class PronunciationAnalysisController {
           })
           .tap(progress => {
             reportProgress(progress);
+          })
+          .then(() => {
+            // This session is over.
+            self.connection._analysisId = null;
           });
-        // This session is over.
-        self.connection._analysisId = null;
       }
 
       recorder.addEventListener('recorded', stopListening);

--- a/administrative-sdk/speech-recording/speech-recording-controller.js
+++ b/administrative-sdk/speech-recording/speech-recording-controller.js
@@ -121,11 +121,12 @@ module.exports = class SpeechRecordingController {
           res => {
             Connection.logRPCError(res);
             reject(res);
-          }
-        );
+          })
+          .then(() => {
+            self.connection._recordingId = null;
+          });
         recorder.removeEventListener('recorded', recordedCb);
         recorder.removeEventListener('dataavailable', startStreaming);
-        self.connection._recordingId = null;
       }
 
       // Start streaming the binary audio when the user instructs

--- a/test/choice-recognitionSpec.js
+++ b/test/choice-recognitionSpec.js
@@ -211,12 +211,13 @@ describe('ChoiceRecognition Websocket API interaction test', () => {
       .progress(() => {
         progressCalled = true;
       })
-      .then(() => {
+      .then(result => {
         expect(api._session.call).toHaveBeenCalled();
         expect(api._session.call).toHaveBeenCalledWith(
           'nl.itslanguage.choice.init_recognition', [],
           {trimStart: 0.15, trimEnd: 0});
         expect(progressCalled).toBeTruthy();
+        expect(result.recognitionId).toBe(fakeResponse);
       })
       .catch(error => {
         fail('No error should be thrown ' + error);

--- a/test/pronunciation-analysisSpec.js
+++ b/test/pronunciation-analysisSpec.js
@@ -422,13 +422,14 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
       .progress(() => {
         progressCalled = true;
       })
-      .then(() => {
+      .then(result => {
         expect(api._session.call).toHaveBeenCalled();
         expect(api._session.call).toHaveBeenCalledWith(
           'nl.itslanguage.pronunciation.init_analysis', [],
           {trimStart: 0.15, trimEnd: 0.0});
         expect(controller.referenceAlignment).toEqual('AlignmentResult');
         expect(progressCalled).toBeTruthy();
+        expect(result.analysisId).toEqual(fakeResponse);
       })
       .catch(error => {
         fail('No error should be thrown: ' + error);

--- a/test/speech-recordingSpec.js
+++ b/test/speech-recordingSpec.js
@@ -527,6 +527,7 @@ describe('Speech Recording Websocket API interaction test', () => {
         expect(api._session.call).toHaveBeenCalledWith(
           'nl.itslanguage.recording.init_recording', []);
         expect(progressCalled).toBeTruthy();
+        expect(result.recordingId).toEqual(fakeResponse);
       })
       .catch(error => {
         fail('No error should be thrown: ' + error);


### PR DESCRIPTION
Fix recording, recognition and analysis id set to null before being returned to user.