### PR TITLE
refactor(pronunciationanalysis): use progress instead of tap

### DIFF
--- a/administrative-sdk/pronunciation-analysis/pronunciation-analysis-controller.js
+++ b/administrative-sdk/pronunciation-analysis/pronunciation-analysis-controller.js
@@ -219,7 +219,7 @@ module.exports = class PronunciationAnalysisController {
             }
             reportError(res.kwargs.analysis);
           })
-          .tap(progress => {
+          .progress(progress => {
             reportProgress(progress);
           })
           .then(() => {


### PR DESCRIPTION
Use the .progress method on call promise to send out intermediate
messages instead of .tap which executed on completion of the promise.