### PR TITLE
feat(mediaplayers): add stop and pause functionality

### DIFF
--- a/audio-player.js
+++ b/audio-player.js
@@ -39,6 +39,9 @@ module.exports = class AudioPlayer {
       stoppedCb() {
         self.emitter.emit('stopped', []);
       },
+      playbackStoppedCb() {
+        self.emitter.emit('playbackstopped', []);
+      },
       progressCb() {
         self.emitter.emit('progress', []);
       },

--- a/audio-player.js
+++ b/audio-player.js
@@ -36,6 +36,9 @@ module.exports = class AudioPlayer {
       pauseCb() {
         self.emitter.emit('pause', []);
       },
+      stoppedCb() {
+        self.emitter.emit('stopped', []);
+      },
       progressCb() {
         self.emitter.emit('progress', []);
       },
@@ -194,12 +197,16 @@ module.exports = class AudioPlayer {
     this.player.stop();
   }
 
+  pause() {
+    this.player.pause();
+  }
+
   /**
    * Toggle audio playback. Switch from playing to paused state and back.
    */
   togglePlayback() {
     if (this.player.isPlaying()) {
-      this.player.stop();
+      this.player.pause();
     } else {
       this.player.play();
     }

--- a/cordova-media-player.js
+++ b/cordova-media-player.js
@@ -202,6 +202,11 @@ module.exports = class CordovaMediaPlayer {
    */
   stop() {
     this._isPlaying = false;
+    this.sound.stop();
+  }
+
+  pause() {
+    this._isPlaying = false;
     this.sound.pause();
   }
 

--- a/test/audio-playerSpec.js
+++ b/test/audio-playerSpec.js
@@ -194,23 +194,30 @@ describe('Audio player', () => {
     expect(player.player.stop).toHaveBeenCalledTimes(1);
   });
 
+  it('should pause', () => {
+    const player = new AudioPlayer();
+    player.player = jasmine.createSpyObj('player', ['pause']);
+    player.pause();
+    expect(player.player.pause).toHaveBeenCalledTimes(1);
+  });
+
   it('should toggle playback when playing', () => {
     const player = new AudioPlayer();
-    player.player = jasmine.createSpyObj('player', ['play', 'stop', 'isPlaying']);
+    player.player = jasmine.createSpyObj('player', ['play', 'pause', 'isPlaying']);
     player.player.isPlaying.and.returnValue(true);
     player.togglePlayback();
     expect(player.player.isPlaying).toHaveBeenCalledTimes(1);
-    expect(player.player.stop).toHaveBeenCalledTimes(1);
+    expect(player.player.pause).toHaveBeenCalledTimes(1);
     expect(player.player.play).not.toHaveBeenCalled();
   });
 
   it('should toggle playback when not playing', () => {
     const player = new AudioPlayer();
-    player.player = jasmine.createSpyObj('player', ['play', 'stop', 'isPlaying']);
+    player.player = jasmine.createSpyObj('player', ['play', 'pause', 'isPlaying']);
     player.player.isPlaying.and.returnValue(false);
     player.togglePlayback();
     expect(player.player.isPlaying).toHaveBeenCalledTimes(1);
-    expect(player.player.stop).not.toHaveBeenCalledTimes(1);
+    expect(player.player.pause).not.toHaveBeenCalledTimes(1);
     expect(player.player.play).toHaveBeenCalledTimes(1);
   });
 

--- a/test/cordova-media-playerSpec.js
+++ b/test/cordova-media-playerSpec.js
@@ -221,10 +221,20 @@ describe('Cordova Media Player', () => {
 
   it('should stop', () => {
     player.sound = {
-      pause: jasmine.createSpy()
+      stop: jasmine.createSpy()
     };
     player._isPlaying = true;
     player.stop();
+    expect(player._canPlay).toBeFalsy();
+    expect(player.sound.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pause', () => {
+    player.sound = {
+      pause: jasmine.createSpy()
+    };
+    player._isPlaying = true;
+    player.pause();
     expect(player._canPlay).toBeFalsy();
     expect(player.sound.pause).toHaveBeenCalledTimes(1);
   });

--- a/test/web-audio-playerSpec.js
+++ b/test/web-audio-playerSpec.js
@@ -58,6 +58,7 @@ describe('WebAudioPlayer', () => {
         'canplayCb',
         'endedCb',
         'pauseCb',
+        'stoppedCb',
         'progressCb',
         'errorCb'
       ]);
@@ -73,6 +74,7 @@ describe('WebAudioPlayer', () => {
       expect(options.canplayCb).toHaveBeenCalledTimes(1);
       expect(options.endedCb).toHaveBeenCalledTimes(1);
       expect(options.pauseCb).toHaveBeenCalledTimes(1);
+      expect(options.stoppedCb).toHaveBeenCalledTimes(2);
       expect(options.progressCb).toHaveBeenCalledTimes(1);
       expect(options.errorCb).toHaveBeenCalledTimes(5);
       expect(console.error).toHaveBeenCalledTimes(5);
@@ -222,11 +224,26 @@ describe('WebAudioPlayer', () => {
   it('should stop playing audio', () => {
     audioMock.pause = () => {
     };
+    audioMock.currentTime = 10;
     spyOn(audioMock, 'pause');
     webAudioPlayer = new WebAudioPlayer();
     webAudioPlayer.stop();
 
+    expect(webAudioPlayer._pauseIsStop).toEqual(false);
+    expect(audioMock.currentTime).toEqual(0);
+    expect(audioMock.pause).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pause playing audio', () => {
+    audioMock.pause = () => {
+    };
+    audioMock.currentTime = 10;
+    spyOn(audioMock, 'pause');
+    webAudioPlayer = new WebAudioPlayer();
+    webAudioPlayer.pause();
+
     expect(webAudioPlayer._pauseIsStop).toEqual(true);
+    expect(audioMock.currentTime).toEqual(10);
     expect(audioMock.pause).toHaveBeenCalledTimes(1);
   });
 

--- a/test/web-audio-playerSpec.js
+++ b/test/web-audio-playerSpec.js
@@ -59,6 +59,7 @@ describe('WebAudioPlayer', () => {
         'endedCb',
         'pauseCb',
         'stoppedCb',
+        'playbackStoppedCb',
         'progressCb',
         'errorCb'
       ]);
@@ -74,7 +75,8 @@ describe('WebAudioPlayer', () => {
       expect(options.canplayCb).toHaveBeenCalledTimes(1);
       expect(options.endedCb).toHaveBeenCalledTimes(1);
       expect(options.pauseCb).toHaveBeenCalledTimes(1);
-      expect(options.stoppedCb).toHaveBeenCalledTimes(2);
+      expect(options.stoppedCb).toHaveBeenCalledTimes(1);
+      expect(options.playbackStoppedCb).toHaveBeenCalledTimes(2);
       expect(options.progressCb).toHaveBeenCalledTimes(1);
       expect(options.errorCb).toHaveBeenCalledTimes(5);
       expect(console.error).toHaveBeenCalledTimes(5);

--- a/web-audio-player.js
+++ b/web-audio-player.js
@@ -69,9 +69,11 @@ module.exports = class WebAudioPlayer {
         if (self.settings.pauseCb) {
           self.settings.pauseCb();
         }
-      }
-      if (self.settings.stoppedCb) {
+      } else if (self.settings.stoppedCb) {
         self.settings.stoppedCb();
+      }
+      if (self.settings.playbackStoppedCb) {
+        self.settings.playbackStoppedCb();
       }
     });
 

--- a/web-audio-player.js
+++ b/web-audio-player.js
@@ -70,6 +70,9 @@ module.exports = class WebAudioPlayer {
           self.settings.pauseCb();
         }
       }
+      if (self.settings.stoppedCb) {
+        self.settings.stoppedCb();
+      }
     });
 
     this.sound.addEventListener('progress', () => {
@@ -182,6 +185,11 @@ module.exports = class WebAudioPlayer {
   stop() {
     // The HTML5 audio player only has a pause(), no stop().
     // To differentiate between the two, set a flag.
+    this.sound.pause();
+    this.sound.currentTime = 0;
+  }
+
+  pause() {
     this._pauseIsStop = true;
     this.sound.pause();
   }


### PR DESCRIPTION
Add a pause method in addition to the existing stop method. This allows
for people to react to events coming from either an actual pause of the
audio playing, or a stop, which also resets the audio time back to 0.