### PR TITLE
fix(stopwatch): fix ticking behaviour

### DIFF
--- a/test/toolsSpec.js
+++ b/test/toolsSpec.js
@@ -50,10 +50,10 @@ describe('Stopwatch', () => {
     const stopwatch = new Stopwatch(cb);
     stopwatch.update();
     expect(stopwatch.value).toEqual(1);
-    expect(cb).toHaveBeenCalledWith(1);
+    expect(cb).toHaveBeenCalledWith(0);
     stopwatch.update();
     expect(stopwatch.value).toEqual(2);
-    expect(cb).toHaveBeenCalledWith(2);
+    expect(cb).toHaveBeenCalledWith(1);
   });
 
   it('should update without cb', () => {

--- a/tools.js
+++ b/tools.js
@@ -52,10 +52,15 @@ class Stopwatch {
   reset() {
     console.debug('Reset count');
     this.value = 0;
+    this.tick();
   }
 
   update() {
+    this.tick();
     this.value++;
+  }
+
+  tick() {
     if (this.tickCb) {
       this.tickCb(this.value);
     }


### PR DESCRIPTION
Fix ticking behaviour to update value after using the callback and
to use the callback when resetting the timer.