### PR TITLE
refactor(connection): use one method to connect

### DIFF
--- a/administrative-sdk/connection/connection-controller.js
+++ b/administrative-sdk/connection/connection-controller.js
@@ -52,14 +52,6 @@ module.exports = class Connection {
    *
    */
   webSocketConnect(accessToken) {
-    this._webSocketConnect(accessToken, autobahn);
-  }
-
-  /**
-   * Create a connection to the websocket server.
-   *
-   */
-  _webSocketConnect(accessToken, autobahnSource) {
     /**
      * This callback is fired during Ticket-based authentication
      *
@@ -76,7 +68,7 @@ module.exports = class Connection {
     // Open a websocket connection for streaming audio
     try {
       // Set up WAMP connection to router
-      connection = new autobahnSource.Connection({
+      connection = new autobahn.Connection({
         url: authUrl,
         realm: 'default',
         // the following attributes must be set for Ticket-based authentication

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -437,12 +437,6 @@ describe('Connection', () => {
     window.WebSocket = backupSocket;
   });
 
-  it('should call the connect method', () => {
-    spyOn(api, '_webSocketConnect');
-    api.webSocketConnect('token');
-    expect(api._webSocketConnect).toHaveBeenCalledWith('token', jasmine.any(Object));
-  });
-
   describe('Cancel streaming', () => {
     let recorderMock;
     beforeEach(() => {
@@ -503,7 +497,8 @@ describe('Autobahn', () => {
       }
     };
     spyOn(console, 'log');
-    api._webSocketConnect('token', mockBahn);
+    Connection.__set__('autobahn', mockBahn);
+    api.webSocketConnect('token');
     expect(console.log).toHaveBeenCalledTimes(1);
     expect(console.log).toHaveBeenCalledWith('WebSocket creation error: Error: Cannot construct');
   });
@@ -531,7 +526,8 @@ describe('Autobahn', () => {
     spyOn(api, 'fireEvent');
     spyOn(console, 'log');
     spyOn(console, 'debug');
-    api._webSocketConnect('token', mockBahn);
+    Connection.__set__('autobahn', mockBahn);
+    api.webSocketConnect('token');
     mockSession.call('apiUrl', 'extra argument');
     expect(api.fireEvent).toHaveBeenCalledWith('websocketError', ['error']);
     expect(console.log).toHaveBeenCalledWith('WebSocket error: error');
@@ -558,8 +554,9 @@ describe('Autobahn', () => {
         };
       }
     };
+    Connection.__set__('autobahn', mockBahn);
     expect(() => {
-      api._webSocketConnect('token', mockBahn);
+      api.webSocketConnect('token');
     }).toThrowError('don\'t know how to authenticate using \'cra\'');
   });
 });


### PR DESCRIPTION
Remove the intermediate method to _websocketconnect. Previously this
was used so autobahn could be mocked, but with rewireify it is no
longer needed to do it like this.