### PR TITLE
fix(promises): fix promise response

### DIFF
--- a/administrative-sdk/basic-auth/basic-auth-controller.js
+++ b/administrative-sdk/basic-auth/basic-auth-controller.js
@@ -21,7 +21,30 @@ module.exports = class BasicAuthController {
   createBasicAuth(basicAuth) {
     const url = this.connection.settings.apiUrl + '/basicauths';
     const formData = JSON.stringify(basicAuth);
-    return this.connection._secureAjaxPost(url, formData)
+    const headers = new Headers();
+    if (typeof formData === 'string') {
+      headers.append('Content-Type',
+        'application/json; charset=utf-8');
+    }
+    const options = {
+      method: 'POST',
+      headers,
+      body: formData
+    };
+    return fetch(url, options)
+      .then(response =>
+        response.text()
+          .then(textResponse => {
+            if (!textResponse) {
+              return Promise.reject(response.status + ': ' + response.statusText);
+            }
+            const result = JSON.parse(textResponse);
+            if (response.ok) {
+              return result;
+            }
+            return Promise.reject(result);
+          })
+      )
       .then(data => {
         const result = new BasicAuth(data.tenantId, data.principal, basicAuth.credentials);
         result.created = new Date(data.created);

--- a/administrative-sdk/connection/connection-controller.js
+++ b/administrative-sdk/connection/connection-controller.js
@@ -125,12 +125,16 @@ module.exports = class Connection {
         };
         return fetch(url, options)
           .then(response =>
-            response.json()
-              .then(data => {
-                if (response.ok) {
-                  return data;
+            response.text()
+              .then(textResponse => {
+                if (!textResponse) {
+                  return Promise.reject(response.status + ': ' + response.statusText);
                 }
-                throw data;
+                const result = JSON.parse(textResponse);
+                if (response.ok) {
+                  return result;
+                }
+                return Promise.reject(result);
               })
           );
       });
@@ -161,12 +165,16 @@ module.exports = class Connection {
         };
         return fetch(url, options)
           .then(response =>
-            response.json()
-              .then(data => {
-                if (response.ok) {
-                  return data;
+            response.text()
+              .then(textResponse => {
+                if (!textResponse) {
+                  return Promise.reject(response.status + ': ' + response.statusText);
                 }
-                throw data;
+                const result = JSON.parse(textResponse);
+                if (response.ok) {
+                  return result;
+                }
+                return Promise.reject(result);
               })
           );
       });
@@ -191,12 +199,16 @@ module.exports = class Connection {
         };
         return fetch(url, options)
           .then(response =>
-            response.json()
-              .then(data => {
-                if (response.ok) {
-                  return data;
+            response.text()
+              .then(textResponse => {
+                if (!textResponse) {
+                  return Promise.reject(response.status + ': ' + response.statusText);
                 }
-                throw data;
+                const result = JSON.parse(textResponse);
+                if (response.ok) {
+                  return result;
+                }
+                return Promise.reject(result);
               })
           );
       });

--- a/test/basic-authSpec.js
+++ b/test/basic-authSpec.js
@@ -164,4 +164,36 @@ describe('BasicAuth API interaction test', () => {
       })
       .then(done);
   });
+
+  it('should handle an empty response while creating a new basicauth', done => {
+    const api = new Connection({
+      oAuth2Token: 'token'
+    });
+    const basicauth = new BasicAuth('4', 'principal');
+    const controller = new BasicAuthController(api);
+    const fakeResponse = new Response(JSON.stringify(), {
+      status: 400,
+      statusText: 'Bad Request',
+      header: {
+        'Content-type': 'application/json'
+      }
+    });
+
+    spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
+
+    controller.createBasicAuth(basicauth)
+      .then(() => {
+        fail('No result should be returned');
+      })
+      .catch(error => {
+        const expected = {tenantId: '4', principal: 'principal'};
+        const url = 'https://api.itslanguage.nl/basicauths';
+        const request = window.fetch.calls.mostRecent().args;
+        expect(request[0]).toBe(url);
+        expect(request[1].method).toBe('POST');
+        expect(request[1].body).toEqual(JSON.stringify(expected));
+        expect(error).toEqual('400: Bad Request');
+      })
+      .then(done);
+  });
 });

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -223,6 +223,63 @@ describe('Connection', () => {
           })
           .then(done);
       });
+
+      it('should handle errors with an empty response on GET', done => {
+        fakeResponse = new Response(JSON.stringify(), {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxGet(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('400: Bad Request');
+          })
+          .then(done);
+      });
+
+      it('should handle errors with an empty response on POST', done => {
+        fakeResponse = new Response(JSON.stringify(), {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxPost(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('400: Bad Request');
+          })
+          .then(done);
+      });
+
+      it('should handle errors with an empty response on DELETE', done => {
+        fakeResponse = new Response(JSON.stringify(), {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxDelete(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('400: Bad Request');
+          })
+          .then(done);
+      });
     });
   });
 


### PR DESCRIPTION
Fix errors being thrown if the server responded with nothing.
The .json method expected a json object but if the server responded
with nothing an error would be thrown. First parse the response to text and see if something exists and then handle it further.