### PR TITLE
fix(connection): add response checking for string

### DIFF
--- a/administrative-sdk/connection/connection-controller.js
+++ b/administrative-sdk/connection/connection-controller.js
@@ -128,7 +128,13 @@ module.exports = class Connection {
                 if (!textResponse) {
                   return Promise.reject(response.status + ': ' + response.statusText);
                 }
-                const result = JSON.parse(textResponse);
+
+                let result;
+                try {
+                  result = JSON.parse(textResponse);
+                } catch (e) {
+                  result = textResponse;
+                }
                 if (response.ok) {
                   return result;
                 }
@@ -166,7 +172,13 @@ module.exports = class Connection {
                 if (!textResponse) {
                   return Promise.reject(response.status + ': ' + response.statusText);
                 }
-                const result = JSON.parse(textResponse);
+
+                let result;
+                try {
+                  result = JSON.parse(textResponse);
+                } catch (e) {
+                  result = textResponse;
+                }
                 if (response.ok) {
                   return result;
                 }
@@ -198,7 +210,14 @@ module.exports = class Connection {
                 if (!textResponse) {
                   return Promise.reject(response.status + ': ' + response.statusText);
                 }
-                const result = JSON.parse(textResponse);
+
+                let result;
+                try {
+                  result = JSON.parse(textResponse);
+                } catch (e) {
+                  result = textResponse;
+                }
+
                 if (response.ok) {
                   return result;
                 }

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -280,6 +280,63 @@ describe('Connection', () => {
           })
           .then(done);
       });
+
+      it('should handle errors with a string response on GET', done => {
+        fakeResponse = new Response('string response', {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxGet(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('string response');
+          })
+          .then(done);
+      });
+
+      it('should handle errors with a string response on POST', done => {
+        fakeResponse = new Response('string response', {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxPost(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('string response');
+          })
+          .then(done);
+      });
+
+      it('should handle errors with a string response on DELETE', done => {
+        fakeResponse = new Response('string response', {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxDelete(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('string response');
+          })
+          .then(done);
+      });
     });
   });
 


### PR DESCRIPTION
In addition to responding with an empty body, the server can also
respond with just a string. Which also needs to be checked for because
a regular string will crash the json parsing.