### PR TITLE
feat(connection): use token from settings

### DIFF
--- a/administrative-sdk/connection/connection-controller.js
+++ b/administrative-sdk/connection/connection-controller.js
@@ -51,14 +51,15 @@ module.exports = class Connection {
    * Create a connection to the websocket server.
    *
    */
-  webSocketConnect(accessToken) {
+  webSocketConnect() {
+    const self = this;
     /**
      * This callback is fired during Ticket-based authentication
      *
      */
     function onOAuth2Challenge(session, method) {
       if (method === 'ticket') {
-        return accessToken;
+        return self.settings.oAuth2Token;
       }
       throw new Error(`don't know how to authenticate using '${method}'`);
     }
@@ -75,7 +76,7 @@ module.exports = class Connection {
         authmethods: ['ticket'],
         authid: 'oauth2',
         details: {
-          ticket: accessToken
+          ticket: this.settings.oAuth2Token
         },
         onchallenge: onOAuth2Challenge
       });
@@ -83,7 +84,6 @@ module.exports = class Connection {
       console.log('WebSocket creation error: ' + e);
       return;
     }
-    const self = this;
     connection.onerror = function(e) {
       console.log('WebSocket error: ' + e);
       self.fireEvent('websocketError', [e]);

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -567,8 +567,10 @@ describe('Autobahn', () => {
         console.log('Called mock session at ' + url + ' with ' + args);
       }
     };
+    let constructedToken;
     const mockBahn = {
       Connection(options) {
+        constructedToken = options.details.ticket;
         this.onchallenge = options.onchallenge;
         this.onerror = null;
         this.onopen = null;
@@ -585,7 +587,8 @@ describe('Autobahn', () => {
     spyOn(console, 'log');
     spyOn(console, 'debug');
     Connection.__set__('autobahn', mockBahn);
-    api.webSocketConnect('token');
+    api.settings.oAuth2Token = 'token';
+    api.webSocketConnect();
     mockSession.call('apiUrl', 'extra argument');
     expect(api.fireEvent).toHaveBeenCalledWith('websocketError', ['error']);
     expect(console.log).toHaveBeenCalledWith('WebSocket error: error');
@@ -601,6 +604,8 @@ describe('Autobahn', () => {
     expect(console.log).toHaveBeenCalledWith('Called mock session at apiUrl with extra argument');
 
     expect(console.log).toHaveBeenCalledTimes(4);
+
+    expect(constructedToken).toEqual('token');
   });
 
   it('should create an autobahn connection and throw on invalid challenge method', () => {


### PR DESCRIPTION
Use the token to connect from the settings instead of from a parameter.