### PR TITLE
fix(connection): check for string response

### DIFF
--- a/administrative-sdk/connection/connection-controller.js
+++ b/administrative-sdk/connection/connection-controller.js
@@ -215,14 +215,16 @@ export default class Connection {
   handleResponse(response) {
     return response.text()
           .then(textResponse => {
-            if (!textResponse) {
-              return Promise.reject(response.status + ': ' + response.statusText);
+            let result;
+            try {
+              result = JSON.parse(textResponse);
+              if (response.ok) {
+                return result;
+              }
+              return Promise.reject(result);
+            } catch (err) {
+              return Promise.reject(response.status + ': ' + response.statusText + '. ' + textResponse);
             }
-            const result = JSON.parse(textResponse);
-            if (response.ok) {
-              return result;
-            }
-            return Promise.reject(result);
           });
   }
 

--- a/administrative-sdk/connection/connection-controller.js
+++ b/administrative-sdk/connection/connection-controller.js
@@ -223,7 +223,7 @@ export default class Connection {
               }
               return Promise.reject(result);
             } catch (err) {
-              return Promise.reject(response.status + ': ' + response.statusText + '. ' + textResponse);
+              return Promise.reject((response.status + ': ' + response.statusText + '. ' + textResponse).trim());
             }
           });
   }

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -239,7 +239,7 @@ describe('Connection', () => {
             fail('No result should be returned');
           })
           .catch(error => {
-            expect(error).toEqual('400: Bad Request. ');
+            expect(error).toEqual('400: Bad Request.');
           })
           .then(done);
       });
@@ -258,7 +258,7 @@ describe('Connection', () => {
             fail('No result should be returned');
           })
           .catch(error => {
-            expect(error).toEqual('400: Bad Request. ');
+            expect(error).toEqual('400: Bad Request.');
           })
           .then(done);
       });
@@ -277,7 +277,7 @@ describe('Connection', () => {
             fail('No result should be returned');
           })
           .catch(error => {
-            expect(error).toEqual('400: Bad Request. ');
+            expect(error).toEqual('400: Bad Request.');
           })
           .then(done);
       });

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -239,7 +239,7 @@ describe('Connection', () => {
             fail('No result should be returned');
           })
           .catch(error => {
-            expect(error).toEqual('400: Bad Request');
+            expect(error).toEqual('400: Bad Request. ');
           })
           .then(done);
       });
@@ -258,7 +258,7 @@ describe('Connection', () => {
             fail('No result should be returned');
           })
           .catch(error => {
-            expect(error).toEqual('400: Bad Request');
+            expect(error).toEqual('400: Bad Request. ');
           })
           .then(done);
       });
@@ -277,7 +277,64 @@ describe('Connection', () => {
             fail('No result should be returned');
           })
           .catch(error => {
-            expect(error).toEqual('400: Bad Request');
+            expect(error).toEqual('400: Bad Request. ');
+          })
+          .then(done);
+      });
+
+      it('should handle errors with a string response on GET', done => {
+        fakeResponse = new Response('NOT ENOUGH PERMISSIONS', {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxGet(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('400: Bad Request. NOT ENOUGH PERMISSIONS');
+          })
+          .then(done);
+      });
+
+      it('should handle errors with a string response on POST', done => {
+        fakeResponse = new Response('NOT ENOUGH PERMISSIONS', {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxPost(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('400: Bad Request. NOT ENOUGH PERMISSIONS');
+          })
+          .then(done);
+      });
+
+      it('should handle errors with a string response on DELETE', done => {
+        fakeResponse = new Response('NOT ENOUGH PERMISSIONS', {
+          status: 400,
+          statusText: 'Bad Request',
+          header: {
+            'Content-type': 'application/json'
+          }
+        });
+        window.fetch.and.returnValue(Promise.resolve(fakeResponse));
+        api._secureAjaxDelete(url)
+          .then(() => {
+            fail('No result should be returned');
+          })
+          .catch(error => {
+            expect(error).toEqual('400: Bad Request. NOT ENOUGH PERMISSIONS');
           })
           .then(done);
       });


### PR DESCRIPTION
If you have insufficient permissions for calling a method the server will respond with a
string as body. If you tried to parse that to JSON an additional error
would be spit out. So check for strings.