### PR TITLE
fix(deploy): dont build docs on prs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,7 +5,10 @@ set -e # Exit with nonzero exit code if anything fails
 
 SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"
-
+if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" != "$SOURCE_BRANCH" ]; then
+    echo "Skipping deploy; just doing a build."
+    exit 0
+fi
 # Save some useful information
 REPO=`git config remote.origin.url`
 SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}


### PR DESCRIPTION
Don't build docs on PRs or commits to other branches as the environment
variables are not available there.