### PR TITLE
fix(deploy): fix esdoc command

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ chmod 600 itsl_js_deploy_key
 eval `ssh-agent -s`
 ssh-add itsl_js_deploy_key
 
-node_modules/.bin/esdoc -c esdoc.json
+npm run esdoc
 git add esdoc/
 git commit -m "Deploy to GitHub Pages: ${SHA}"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ chmod 600 itsl_js_deploy_key
 eval `ssh-agent -s`
 ssh-add itsl_js_deploy_key
 
-esdoc -c esdoc.json
+node_modules/.bin/esdoc -c esdoc.json
 git add esdoc/
 git commit -m "Deploy to GitHub Pages: ${SHA}"
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "The core JavaScript SDK for ITSLanguage.",
   "main": "index.js",
   "scripts": {
-    "test": "concurrently 'eslint .' 'karma start --single-run --color'"
+    "test": "concurrently 'eslint .' 'karma start --single-run --color'",
+    "esdoc": "esdoc -c esdoc.json"
   },
   "author": "ITSLanguage",
   "license": "MIT",


### PR DESCRIPTION
The deploy script couldn't find esdoc when travis was preparing a release.

`./deploy.sh: line 34: esdoc: command not found`

Was the error travis gave.

I'm open to suggestions on how to make Travis not explode everytime I want to release.