### PR TITLE
chore(travis): skip stash from gh-pages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ deploy:
     script: ./deploy.sh
     on:
       tags: true
+    skip_cleanup: true


### PR DESCRIPTION
The build of the documentation relies on npm, which requires npm
dependencies to have been installed.

This should fix #165.