### PR TITLE
chore(deploy): use babel as npm script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,17 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-before_deploy:
-- babel src --out-dir build --source-maps inline && cp package.json build/
 deploy:
+  - provider: script
+    script: ./deploy.sh
+    on:
+      tags: true
+    skip_cleanup: true
+
   - provider: npm
     email: kvdb@d-centralize.nl
     api_key:
       secure: KlsdLI5KOLYVhkuQTAxxHlBMNcWtKJ3mCoX66jy1vv4CaIaYBrtgpU8BBPoR8zpQOfvpr7LwaOmeSSmCvfsOC3Ai+0XtmJNBeotnpCkHOz5Z7+vFpUmpDjWiCtIkerlZZdCFBIv1t8Lz870RVoTyevZo7txHcr6BD4QMEJcS8siZmGNLOSiUeoJXkpd9e4VNHKjodbm8stCWQjdIQ4f85B/EvGPzS3vosh8M6W++w1j1vNeJXCGfjoI+bfDr1sg0P31h2KBSWmTF+idFMSEWPgbPwq0/rrcUwTrrpaA2mbarNG5aDLRIdmUFdw+xw3TW/TE6euy6SVNFOcE+Wy8BKgOsZLVtz9s6TWB0eHcfoWg5nEwbRwu1FHHItmVMP9nW7aX7mKBlXBnXh5egekw4m6vGwUEe9ayhJs0xXz8vyrvkwJvAtDmx0eGaCLupBbHJRnjZvlLqU+2HeUMxNz3t/MbXdbytazyA5TDiBp5ZSJ9srCoCby0mnFjkQxmgFB6XbEpVz6Zo1e0hOwdP5P7iWxbKzBGvwgK2QjZDhLpCctvTWPGNmO0bUZMbCdVPPRcfIKe2m83CTvVbUy47vzreeiaVhx+Wef0MUr/cm1SvDOoNaIWb2j5eVHUvbOr5+L1uV0peR6oO26xOVmQZzyMBjC+K9vfiGeHUO3t4072C4nk=
-    on:
-      tags: true
-    local_dir: build
-    skip_cleanup: true
-
-  - provider: script
-    script: ./deploy.sh
     on:
       tags: true
     skip_cleanup: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -37,3 +37,7 @@ git commit -m "Deploy to GitHub Pages: ${SHA}"
 
 git subtree split --prefix esdoc/ -b gh-pages
 git push -f origin gh-pages:gh-pages
+
+npm run babelify
+
+cd build/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "concurrently 'eslint .' 'karma start --single-run --color'",
-    "esdoc": "esdoc -c esdoc.json"
+    "esdoc": "esdoc -c esdoc.json",
+    "babelify": "babel src --out-dir build --source-maps inline && cp package.json build/"
   },
   "author": "ITSLanguage",
   "license": "MIT",


### PR DESCRIPTION
Instead of using the babel script `before_deploy`, use it as npm script in
`deploy.sh`, which only runs it once and sets up the right `build/` directory for
the npm release.