### PR TITLE
fix(index): remove stream result exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,17 +4,14 @@ import AudioPlayer from './audio/audio-player';
 import AudioRecorder from './audio/audio-recorder';
 import BasicAuth from './administrative-sdk/basic-auth/basic-auth';
 import ChoiceChallenge from './administrative-sdk/choice-challenge/choice-challenge';
-import ChoiceRecognition from './administrative-sdk/choice-recognition/choice-recognition';
 import Connection from './administrative-sdk/connection/connection-controller';
 import CordovaMediaPlayer from './audio/cordova-media-player';
 import CordovaMediaRecorder from './audio/cordova-media-recorder';
 import MediaRecorder from './audio/media-recorder';
 import Organisation from './administrative-sdk/organisation/organisation';
 import Phoneme from './administrative-sdk/phoneme/phoneme';
-import PronunciationAnalysis from './administrative-sdk/pronunciation-analysis/pronunciation-analysis';
 import PronunciationChallenge from './administrative-sdk/pronunciation-challenge/pronunciation-challenge';
 import SpeechChallenge from './administrative-sdk/speech-challenge/speech-challenge';
-import SpeechRecording from './administrative-sdk/speech-recording/speech-recording';
 import Student from './administrative-sdk/student/student';
 import Tools from './tools';
 import WavePacker from './audio/wave-packer';
@@ -27,14 +24,11 @@ export {
   AdministrativeSDK,
   BasicAuth,
   ChoiceChallenge,
-  ChoiceRecognition,
   Connection,
   Organisation,
   Phoneme,
-  PronunciationAnalysis,
   PronunciationChallenge,
   SpeechChallenge,
-  SpeechRecording,
   Student,
   Word,
   WordChunk,


### PR DESCRIPTION
Remove the exporting of analyses, recordings and recognition classes.
They are obtained as result from streaming and thus do not need to be
created by the user manually.