### PR TITLE
fix(babel): use nondeprecated loose

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015-loose"],
+  "presets": [ ["es2015", {"loose": true}] ],
   "plugins": ["transform-object-assign"]
 }

--- a/test/administrative-sdkSpec.js
+++ b/test/administrative-sdkSpec.js
@@ -22,9 +22,10 @@ describe('Administrative SDK', () => {
     ['createOrganisation', 'getOrganisation', 'listOrganisations']);
   const fakePronunciationAnalysisController = jasmine.createSpyObj('PronunciationAnalysisController',
     ['startStreamingPronunciationAnalysis', 'getPronunciationAnalysis', 'listPronunciationAnalyses']);
-  const fakePronunciationChallengeController = jasmine.createSpyObj('PronunciationChallengeController',
-    ['createPronunciationChallenge', 'getPronunciationChallenge', 'listPronunciationChallenges',
-      'deletePronunciationChallenge']);
+  const fakePronunciationChallengeController = jasmine.createSpyObj(
+    'PronunciationChallengeController',
+    ['createPronunciationChallenge', 'getPronunciationChallenge',
+      'listPronunciationChallenges', 'deletePronunciationChallenge']);
   const fakeSpeechChallengeController = jasmine.createSpyObj('SpeechChallengeController',
     ['createSpeechChallenge', 'getSpeechChallenge', 'listSpeechChallenges']);
   const fakeSpeechRecordingController = jasmine.createSpyObj('SpeechRecordingController',


### PR DESCRIPTION
Using `2015-loose` mode is deprecated for babel 6+. Use the new method
to use loose mode.