### PR TITLE
refactor(streaming): send streaming id separately

### DIFF
--- a/src/administrative-sdk/choice-recognition/choice-recognition-controller.js
+++ b/src/administrative-sdk/choice-recognition/choice-recognition-controller.js
@@ -123,8 +123,7 @@ export default class ChoiceRecognitionController {
           challenge.id, data.studentId, data.id,
           new Date(data.created), new Date(data.updated),
           self._connection.addAccessToken(data.audioUrl), data.recognised);
-        recognition.recognitionId = self._connection._recognitionId;
-        resolve(recognition);
+        resolve({recognitionId: self._connection._recognitionId, recognition});
       }
 
       function _ecb(data) {

--- a/src/administrative-sdk/speech-recording/speech-recording-controller.js
+++ b/src/administrative-sdk/speech-recording/speech-recording-controller.js
@@ -109,8 +109,7 @@ export default class SpeechRecordingController {
         const recording = new SpeechRecording(
           challenge.id, student, data.id, new Date(data.created), new Date(data.updated),
           self._connection.addAccessToken(data.audioUrl));
-        recording.recordingId = self._connection._recordingId;
-        resolve(recording);
+        resolve({recordingId: self._connection._recordingId, recording});
       }
 
       function recordedCb(activeRecordingId, audioBlob, forcedStop) {

--- a/test/choice-recognitionSpec.js
+++ b/test/choice-recognitionSpec.js
@@ -73,6 +73,7 @@ describe('ChoiceRecognition Websocket API interaction test', () => {
     recorder = new RecorderMock();
     stringDate = '2014-12-31T23:59:59Z';
     fakeResponse = {
+      id: '4',
       created: new Date(stringDate),
       updated: new Date(stringDate),
       audioFormat: 'audio/wave',
@@ -199,6 +200,8 @@ describe('ChoiceRecognition Websocket API interaction test', () => {
           'nl.itslanguage.choice.init_recognition', [],
           {trimStart: 0.15, trimEnd: 0});
         expect(progressCalled).toBeTruthy();
+        expect(result.recognition.challenge).toEqual(challenge.id);
+        expect(result.recognition.id).toEqual('4');
         expect(result.recognitionId).toBe(fakeResponse);
       })
       .catch(error => {
@@ -209,11 +212,14 @@ describe('ChoiceRecognition Websocket API interaction test', () => {
 
   it('should start streaming a new choice recognition without trimming', done => {
     controller.startStreamingChoiceRecognition(challenge, recorder, false)
-        .then(() => {
+        .then(result => {
           expect(api._session.call).toHaveBeenCalled();
           expect(api._session.call).toHaveBeenCalledWith(
             'nl.itslanguage.choice.init_recognition', [],
             {trimStart: 0.00, trimEnd: 0});
+          expect(result.recognition.challenge).toEqual(challenge.id);
+          expect(result.recognition.id).toEqual('4');
+          expect(result.recognitionId).toEqual(fakeResponse);
         })
         .catch(error => {
           fail('No error should be thrown ' + error);

--- a/test/pronunciation-analysisSpec.js
+++ b/test/pronunciation-analysisSpec.js
@@ -83,6 +83,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
     recorder = new RecorderMock();
     stringDate = '2014-12-31T23:59:59Z';
     fakeResponse = {
+      id: '4',
       created: new Date(stringDate),
       updated: new Date(stringDate),
       audioFormat: 'audio/wave',
@@ -776,6 +777,8 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
           {trimStart: 0.15, trimEnd: 0.0});
         expect(progressCalled[0]).toEqual('ReadyToReceive');
         expect(progressCalled[1]).toEqual(expectedNotifyCall);
+        expect(result.analysis.challenge).toEqual(challenge.id);
+        expect(result.analysis.id).toEqual('4');
         expect(result.analysisId).toEqual(fakeResponse);
       })
       .catch(error => {

--- a/test/speech-recordingSpec.js
+++ b/test/speech-recordingSpec.js
@@ -179,6 +179,7 @@ describe('Speech Recording Websocket API interaction test', () => {
       oAuth2Token: 'token'
     });
     fakeResponse = {
+      id: '4',
       created: new Date(stringDate),
       updated: new Date(stringDate),
       audioFormat: 'audio/wave',
@@ -647,8 +648,9 @@ describe('Speech Recording Websocket API interaction test', () => {
         progressCalled = true;
       })
       .then(result => {
-        expect(result.challenge).toEqual(challenge.id);
-        expect(result.student.organisationId).toBe(challenge.organisationId);
+        expect(result.recording.id).toEqual('4');
+        expect(result.recording.challenge).toEqual(challenge.id);
+        expect(result.recording.student.organisationId).toBe(challenge.organisationId);
         expect(api._session.call).toHaveBeenCalled();
         expect(api._session.call).toHaveBeenCalledWith(
           'nl.itslanguage.recording.init_recording', []);


### PR DESCRIPTION
Resolve the streaming with the streaming id separately from the result
object.