### PR TITLE
docs: make controllers private

### DIFF
--- a/src/administrative-sdk/choice-challenge/choice-challenge-controller.js
+++ b/src/administrative-sdk/choice-challenge/choice-challenge-controller.js
@@ -2,6 +2,7 @@ import ChoiceChallenge from './choice-challenge';
 
 /**
  * Controller class for the {@link ChoiceChallenge} model.
+ * @private
  */
 export default class ChoiceChallengeController {
   /**

--- a/src/administrative-sdk/choice-recognition/choice-recognition-controller.js
+++ b/src/administrative-sdk/choice-recognition/choice-recognition-controller.js
@@ -3,6 +3,7 @@ import ChoiceRecognition from './choice-recognition';
 import when from 'when';
 /**
  * Controller class for the ChoiceRecognition model.
+ * @private
  */
 export default class ChoiceRecognitionController {
   /**

--- a/src/administrative-sdk/organisation/organisation-controller.js
+++ b/src/administrative-sdk/organisation/organisation-controller.js
@@ -2,6 +2,7 @@ import Organisation from './organisation';
 
 /**
  * Controller class for the Organisation model.
+ * @private
  */
 export default class OrganisationController {
   /**

--- a/src/administrative-sdk/pronunciation-analysis/pronunciation-analysis-controller.js
+++ b/src/administrative-sdk/pronunciation-analysis/pronunciation-analysis-controller.js
@@ -11,6 +11,7 @@ import when from 'when';
 
 /**
  * Controller class for the PronunciationAnalysis model.
+ * @private
  */
 export default class PronunciationAnalysisController {
   /**

--- a/src/administrative-sdk/pronunciation-challenge/pronunciation-challenge-controller.js
+++ b/src/administrative-sdk/pronunciation-challenge/pronunciation-challenge-controller.js
@@ -2,6 +2,7 @@ import PronunciationChallenge from './pronunciation-challenge';
 
 /**
  * Controller class for the PronunciationChallenge model.
+ * @private
  */
 export default class PronunciationChallengeController {
   /**

--- a/src/administrative-sdk/speech-challenge/speech-challenge-controller.js
+++ b/src/administrative-sdk/speech-challenge/speech-challenge-controller.js
@@ -2,6 +2,7 @@ import SpeechChallenge from './speech-challenge';
 
 /**
  * Controller class for the SpeechChallenge model.
+ * @private
  */
 export default class SpeechChallengeController {
   /**

--- a/src/administrative-sdk/speech-recording/speech-recording-controller.js
+++ b/src/administrative-sdk/speech-recording/speech-recording-controller.js
@@ -5,6 +5,7 @@ import when from 'when';
 
 /**
  * Controller class for the SpeechRecording model.
+ * @private
  */
 export default class SpeechRecordingController {
   /**

--- a/src/administrative-sdk/student/student-controller.js
+++ b/src/administrative-sdk/student/student-controller.js
@@ -2,6 +2,7 @@ import Student from './student';
 
 /**
  * Controller class for the Student model.
+ * @private
  */
 export default class StudentController {
   /**


### PR DESCRIPTION
Add the private annotation to controllers so they don't show up in
documentation. All method documentation can be read from the main
facade class.