### PR TITLE
chore(package): copy readme to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "concurrently 'eslint .' 'karma start --single-run --color'",
     "esdoc": "esdoc -c esdoc.json",
-    "babelify": "babel src --out-dir build --source-maps inline && cp package.json build/"
+    "babelify": "babel src --out-dir build --source-maps inline && cp package.json README.md build/"
   },
   "author": "ITSLanguage",
   "license": "MIT",


### PR DESCRIPTION
Copy README.md to the build folder so there is something to read on the
npm page.