### PR TITLE
Audio as separate param

### DIFF
--- a/src/administrative-sdk/administrative-sdk.js
+++ b/src/administrative-sdk/administrative-sdk.js
@@ -245,11 +245,12 @@ export default class AdministrativeSDK {
    * Create a speech challenge in the current active {@link Organisation} derived from the OAuth2 scope.
    *
    * @param {SpeechChallenge} speechChallenge - Object to create.
+   * @param {?Blob} audioBlob - Audio fragment to link to the challenge.
    * @returns {Promise.<PronunciationChallenge>} Promise containing the newly created SpeechChallenge.
    * @throws {Promise} If the server returned an error.
    */
-  createSpeechChallenge(speechChallenge) {
-    return this._speechChallengeController.createSpeechChallenge(speechChallenge);
+  createSpeechChallenge(speechChallenge, audioBlob) {
+    return this._speechChallengeController.createSpeechChallenge(speechChallenge, audioBlob);
   }
 
   /**

--- a/src/administrative-sdk/speech-challenge/speech-challenge-controller.js
+++ b/src/administrative-sdk/speech-challenge/speech-challenge-controller.js
@@ -20,20 +20,20 @@ export default class SpeechChallengeController {
    * Create a speech challenge in the current active {@link Organisation} derived from the OAuth2 scope.
    *
    * @param {SpeechChallenge} speechChallenge - Object to create.
+   * @param {?Blob} audioBlob - Audio fragment to link to the challenge.
    * @returns {Promise.<PronunciationChallenge>} Promise containing the newly created SpeechChallenge.
    * @throws {Promise} If the server returned an error.
    */
-  createSpeechChallenge(speechChallenge) {
+  createSpeechChallenge(speechChallenge, audioBlob) {
+    speechChallenge.referenceAudio = audioBlob;
     const fd = JSON.stringify(speechChallenge);
     const url = this._connection._settings.apiUrl + '/challenges/speech';
 
     return this._connection._secureAjaxPost(url, fd)
       .then(data => {
-        const result = new SpeechChallenge(data.id, data.topic);
+        const result = new SpeechChallenge(data.id, data.topic, data.referenceAudioUrl);
         result.created = new Date(data.created);
         result.updated = new Date(data.updated);
-        result.referenceAudio = speechChallenge.referenceAudio;
-        result.referenceAudioUrl = data.referenceAudioUrl || null;
         return result;
       });
   }
@@ -54,7 +54,7 @@ export default class SpeechChallengeController {
 
     return this._connection._secureAjaxGet(url)
       .then(data => {
-        const challenge = new SpeechChallenge(data.id, data.topic);
+        const challenge = new SpeechChallenge(data.id, data.topic, data.referenceAudioUrl);
         challenge.created = new Date(data.created);
         challenge.updated = new Date(data.updated);
         return challenge;
@@ -75,7 +75,7 @@ export default class SpeechChallengeController {
         const challenges = [];
         data.forEach(datum => {
           const challenge = new SpeechChallenge(datum.id,
-            datum.topic);
+            datum.topic, datum.referenceAudioUrl);
           challenge.created = new Date(datum.created);
           challenge.updated = new Date(datum.updated);
           challenges.push(challenge);

--- a/src/administrative-sdk/speech-challenge/speech-challenge.js
+++ b/src/administrative-sdk/speech-challenge/speech-challenge.js
@@ -7,9 +7,10 @@ export default class SpeechChallenge {
    *
    * @param {?string} id - The speech challenge identifier. If none is given, one is generated.
    * @param {?string} topic - A question or topic serving as guidance.
-   * @param {?Blob} referenceAudio - The reference audio fragment.
+   * @param {?string} referenceAudioUrl - The reference audio fragment URL. If one is not yet available or audio is
+   * not yet registered to the challenge it can be set to 'null'.
    */
-  constructor(id, topic, referenceAudio) {
+  constructor(id, topic, referenceAudioUrl) {
     if (id && typeof id !== 'string') {
       throw new Error(
         'id parameter of type "string|null" is required');
@@ -29,21 +30,17 @@ export default class SpeechChallenge {
      * @type {string}
      */
     this.topic = topic;
-    // Field is optional, but if given, then it's validated.
-    if (typeof referenceAudio !== 'object' && referenceAudio) {
+
+    if (referenceAudioUrl !== null && typeof referenceAudioUrl !== 'string') {
       throw new Error(
-        'referenceAudio parameter of type "Blob" is required');
+        'referenceAudioUrl parameter of type "string|null" is required');
     }
-    /**
-     * The reference audio fragment.
-     * @type {Blob}
-     */
-    this.referenceAudio = referenceAudio || null;
+
     /**
      * The reference audio fragment as streaming audio link.
      * @type {string}
      */
-    this.referenceAudioUrl = null;
+    this.referenceAudioUrl = referenceAudioUrl;
 
     /**
      * The creation date of the entity.

--- a/test/administrative-sdkSpec.js
+++ b/test/administrative-sdkSpec.js
@@ -65,7 +65,7 @@ describe('Administrative SDK', () => {
     sdk.getPronunciationChallenge(1, 2);
     sdk.listPronunciationChallenges(1);
     sdk.deletePronunciationChallenge(1);
-    sdk.createSpeechChallenge(1);
+    sdk.createSpeechChallenge(1, 2);
     sdk.getSpeechChallenge(1, 2);
     sdk.listSpeechChallenges(1);
     sdk.startStreamingSpeechRecording(1, 2);
@@ -99,7 +99,7 @@ describe('Administrative SDK', () => {
     expect(fakePronunciationChallengeController.listPronunciationChallenges).toHaveBeenCalledWith();
     expect(fakePronunciationChallengeController.deletePronunciationChallenge).toHaveBeenCalledWith(1);
 
-    expect(fakeSpeechChallengeController.createSpeechChallenge).toHaveBeenCalledWith(1);
+    expect(fakeSpeechChallengeController.createSpeechChallenge).toHaveBeenCalledWith(1, 2);
     expect(fakeSpeechChallengeController.getSpeechChallenge).toHaveBeenCalledWith(1);
     expect(fakeSpeechChallengeController.listSpeechChallenges).toHaveBeenCalledWith();
 

--- a/test/speech-challengeSpec.js
+++ b/test/speech-challengeSpec.js
@@ -8,7 +8,7 @@ describe('SpeechChallenge object test', () => {
       new SpeechChallenge(4);
     }).toThrowError('id parameter of type "string|null" is required');
 
-    [0,{},[],true,false,undefined].map(v =>{
+    [0, {}, [], true, false, undefined].map(v => {
       expect(() => {
         new SpeechChallenge('hi', '1', v);
       }).toThrowError('referenceAudioUrl parameter of type "string|null" is required');
@@ -83,7 +83,7 @@ describe('SpeechChallenge API interaction test', () => {
   });
 
   it('should create a new challenge', done => {
-    const challenge = new SpeechChallenge('1', 'Hi');
+    const challenge = new SpeechChallenge('1', 'Hi', null);
     const content = {
       id: '1',
       created: '2014-12-31T23:59:59Z',
@@ -106,7 +106,7 @@ describe('SpeechChallenge API interaction test', () => {
         expect(request[1].method).toBe('POST');
         expect(request[1].body).toEqual(JSON.stringify(challenge));
         const stringDate = '2014-12-31T23:59:59Z';
-        const outChallenge = new SpeechChallenge('1', 'Hi');
+        const outChallenge = new SpeechChallenge('1', 'Hi', null);
         outChallenge.created = new Date(stringDate);
         outChallenge.updated = new Date(stringDate);
         expect(result).toEqual(outChallenge);
@@ -119,7 +119,7 @@ describe('SpeechChallenge API interaction test', () => {
 
   it('should create a new challenge with referenceAudio', done => {
     const blob = new Blob(['1234567890']);
-    const challenge = new SpeechChallenge('1', 'Hi', blob);
+    const challenge = new SpeechChallenge('1', 'Hi', null);
     const referenceAudioUrl = 'https://api.itslanguage.nl/download' +
       '/YsjdG37bUGseu8-bsJ';
     const content = {
@@ -136,17 +136,16 @@ describe('SpeechChallenge API interaction test', () => {
       }
     });
     spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
-    controller.createSpeechChallenge(challenge)
+    controller.createSpeechChallenge(challenge, blob)
       .then(result => {
         const request = window.fetch.calls.mostRecent().args;
         expect(request[0]).toBe(url);
         expect(request[1].method).toBe('POST');
         expect(request[1].body).toEqual(JSON.stringify(challenge));
         const stringDate = '2014-12-31T23:59:59Z';
-        const outChallenge = new SpeechChallenge('1', 'Hi', blob);
+        const outChallenge = new SpeechChallenge('1', 'Hi', referenceAudioUrl);
         outChallenge.created = new Date(stringDate);
         outChallenge.updated = new Date(stringDate);
-        outChallenge.referenceAudio = challenge.referenceAudio;
         outChallenge.referenceAudioUrl = referenceAudioUrl;
         expect(result).toEqual(outChallenge);
       })
@@ -157,7 +156,7 @@ describe('SpeechChallenge API interaction test', () => {
   });
 
   it('should handle errors while creating a new challenge', done => {
-    const challenge = new SpeechChallenge('1', 'Hi');
+    const challenge = new SpeechChallenge('1', 'Hi', null);
     const content = {
       message: 'Validation failed',
       errors: [
@@ -211,7 +210,8 @@ describe('SpeechChallenge API interaction test', () => {
       id: '4',
       created: '2014-12-31T23:59:59Z',
       updated: '2014-12-31T23:59:59Z',
-      topic: 'Hi'
+      topic: 'Hi',
+      referenceAudioUrl: null
     };
     const fakeResponse = new Response(JSON.stringify(content), {
       status: 200,
@@ -226,7 +226,7 @@ describe('SpeechChallenge API interaction test', () => {
         expect(request[0]).toBe(url);
         expect(request[1].method).toBe('GET');
         const stringDate = '2014-12-31T23:59:59Z';
-        const challenge = new SpeechChallenge('4', 'Hi');
+        const challenge = new SpeechChallenge('4', 'Hi', null);
         challenge.created = new Date(stringDate);
         challenge.updated = new Date(stringDate);
         expect(result).toEqual(challenge);
@@ -242,7 +242,8 @@ describe('SpeechChallenge API interaction test', () => {
       id: '4',
       created: '2014-12-31T23:59:59Z',
       updated: '2014-12-31T23:59:59Z',
-      topic: 'Hi'
+      topic: 'Hi',
+      referenceAudioUrl: null
     }];
     const fakeResponse = new Response(JSON.stringify(content), {
       status: 200,
@@ -257,7 +258,7 @@ describe('SpeechChallenge API interaction test', () => {
         expect(request[0]).toBe(url);
         expect(request[1].method).toBe('GET');
         const stringDate = '2014-12-31T23:59:59Z';
-        const challenge = new SpeechChallenge('4', 'Hi');
+        const challenge = new SpeechChallenge('4', 'Hi', null);
         challenge.created = new Date(stringDate);
         challenge.updated = new Date(stringDate);
         expect(result[0]).toEqual(challenge);

--- a/test/speech-challengeSpec.js
+++ b/test/speech-challengeSpec.js
@@ -8,29 +8,31 @@ describe('SpeechChallenge object test', () => {
       new SpeechChallenge(4);
     }).toThrowError('id parameter of type "string|null" is required');
 
-    expect(() => {
-      new SpeechChallenge('hi', '1', '1');
-    }).toThrowError('referenceAudio parameter of type "Blob" is required');
+    [0,{},[],true,false,undefined].map(v =>{
+      expect(() => {
+        new SpeechChallenge('hi', '1', v);
+      }).toThrowError('referenceAudioUrl parameter of type "string|null" is required');
+    });
 
     expect(() => {
       new SpeechChallenge('1', 66);
     }).toThrowError('topic parameter of type "string" is required');
   });
-  it('should instantiate a SpeechChallenge with referenceAudio', () => {
-    const blob = new Blob(['1234567890']);
+  it('should instantiate a SpeechChallenge with referenceAudioUrl', () => {
+    const url = 'www.downloadaudiohere.exe.com';
 
-    const s = new SpeechChallenge('test', 'hi', blob);
+    const s = new SpeechChallenge('test', 'hi', url);
     expect(s).toBeDefined();
     expect(s.id).toBe('test');
     expect(s.topic).toBe('hi');
-    expect(s.referenceAudio).toBe(blob);
+    expect(s.referenceAudioUrl).toBe(url);
   });
   it('should instantiate a SpeechChallenge', () => {
-    const s = new SpeechChallenge('test', 'hi');
+    const s = new SpeechChallenge('test', 'hi', null);
     expect(s).toBeDefined();
     expect(s.id).toBe('test');
     expect(s.topic).toBe('hi');
-    expect(s.referenceAudio).toBe(null);
+    expect(s.referenceAudioUrl).toBe(null);
   });
 });
 
@@ -46,12 +48,13 @@ describe('SpeechChallenge API interaction test', () => {
   });
 
   it('should create a challenge without an id', done => {
-    const challenge = new SpeechChallenge(null, 'Hi');
+    const challenge = new SpeechChallenge(null, 'Hi', null);
     const content = {
       id: '1',
       created: '2014-12-31T23:59:59Z',
       updated: '2014-12-31T23:59:59Z',
-      topic: 'Hi'
+      topic: 'Hi',
+      referenceAudioUrl: null
     };
     const fakeResponse = new Response(JSON.stringify(content), {
       status: 201,
@@ -68,7 +71,7 @@ describe('SpeechChallenge API interaction test', () => {
         expect(request[1].method).toBe('POST');
         expect(request[1].body).toEqual(JSON.stringify(challenge));
         const stringDate = '2014-12-31T23:59:59Z';
-        const outChallenge = new SpeechChallenge('1', 'Hi');
+        const outChallenge = new SpeechChallenge('1', 'Hi', null);
         outChallenge.created = new Date(stringDate);
         outChallenge.updated = new Date(stringDate);
         expect(result).toEqual(outChallenge);
@@ -85,7 +88,8 @@ describe('SpeechChallenge API interaction test', () => {
       id: '1',
       created: '2014-12-31T23:59:59Z',
       updated: '2014-12-31T23:59:59Z',
-      topic: 'Hi'
+      topic: 'Hi',
+      referenceAudioUrl: null
     };
     const fakeResponse = new Response(JSON.stringify(content), {
       status: 201,

--- a/test/speech-recordingSpec.js
+++ b/test/speech-recordingSpec.js
@@ -16,7 +16,7 @@ describe('SpeechRecording API interaction test', () => {
   });
 
   it('should reject to get a recording if challenge id is not present', done => {
-    const challenge = new SpeechChallenge('');
+    const challenge = new SpeechChallenge('', null, null);
     controller.getSpeechRecording(challenge.id, null)
       .then(() => {
         fail('An error should be thrown');
@@ -28,7 +28,7 @@ describe('SpeechRecording API interaction test', () => {
   });
 
   it('should reject to get a recording if recording id is not present', done => {
-    const challenge = new SpeechChallenge('1');
+    const challenge = new SpeechChallenge('1', null, null);
     controller.getSpeechRecording(challenge.id)
       .then(() => {
         fail('An error should be thrown');
@@ -57,7 +57,7 @@ describe('SpeechRecording API interaction test', () => {
     });
     spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
 
-    const challenge = new SpeechChallenge('4');
+    const challenge = new SpeechChallenge('4', null, null);
     controller.getSpeechRecording(challenge.id, '5')
       .then(result => {
         const request = window.fetch.calls.mostRecent().args;
@@ -104,7 +104,7 @@ describe('SpeechRecording API interaction test', () => {
       }
     });
     spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
-    const challenge = new SpeechChallenge('4');
+    const challenge = new SpeechChallenge('4', null, null);
     controller.listSpeechRecordings(challenge.id)
       .then(result => {
         const request = window.fetch.calls.mostRecent().args;
@@ -197,7 +197,7 @@ describe('Speech Recording Websocket API interaction test', () => {
         return d.promise;
       };
     };
-    challenge = new SpeechChallenge('4');
+    challenge = new SpeechChallenge('4', null, null);
     recorder = new RecorderMock();
     session = new SessionMock();
     stringDate = '2014-12-31T23:59:59Z';


### PR DESCRIPTION
When creating a speech challenge, require the audio blob as a separate parameter, since it is not returned by the API (only the download url) and is thus unnecesary in the model.