### PR TITLE
feat(audioplayer): add playbackrate manipulation

### DIFF
--- a/src/audio/audio-player.js
+++ b/src/audio/audio-player.js
@@ -335,6 +335,30 @@ export default class AudioPlayer {
   }
 
   /**
+   * Set the playback rate of the audio. Values are used according to HTML5 Audio.
+   * Example values:
+   * *1.0 is normal speed.
+   * *0.5 is half speed (slower).
+   * *2.0 is double speed (faster).
+   * *-1.0 is backwards, normal speed.
+   * *-0.5 is backwards, half speed.
+   *
+   * @param {number} rate - Rate at which the change the audio playback.
+   */
+  setPlaybackRate(rate) {
+    this._player.setPlaybackRate(rate);
+  }
+
+  /**
+   * Get the playback rate of the current loaded audio.
+   *
+   * @returns {number} Playback rate of the audio.
+   */
+  getPlaybackRate() {
+    return this._player.getPlaybackRate();
+  }
+
+  /**
    * Bind a stopwatch to sync with the playing and stopping functionality of the player.
    *
    * @param {Function} tickCb - Callback to invoke on every tick. A tick occurs once every 100 ms.
@@ -343,7 +367,7 @@ export default class AudioPlayer {
    */
   bindStopwatch(tickCb) {
     this._stopwatch = new Stopwatch(time => {
-      const duration = this.getDuration() * 10;
+      const duration = this.getDuration() * 10 / this._player.sound.playbackRate;
       if (time > duration) {
         tickCb(duration);
       } else {

--- a/src/audio/audio-player.js
+++ b/src/audio/audio-player.js
@@ -343,7 +343,7 @@ export default class AudioPlayer {
    * *-1.0 is backwards, normal speed.
    * *-0.5 is backwards, half speed.
    *
-   * @param {number} rate - Rate at which the change the audio playback.
+   * @param {number} rate - Rate at which to change the audio playback.
    */
   setPlaybackRate(rate) {
     this._player.setPlaybackRate(rate);

--- a/src/audio/cordova-media-player.js
+++ b/src/audio/cordova-media-player.js
@@ -211,6 +211,15 @@ export default class CordovaMediaPlayer {
     // This is a noop.
   }
 
+  getPlaybackRate() {
+    // This is a noop.
+  }
+
+  setPlaybackRate(rate) {
+    // XXX: Not implemented yet.
+    return rate;
+  }
+
 
   /**
    * Start playing audio at the given offset.

--- a/src/audio/web-audio-player.js
+++ b/src/audio/web-audio-player.js
@@ -304,6 +304,14 @@ export default class WebAudioPlayer {
     return !this.sound.paused;
   }
 
+  setPlaybackRate(rate) {
+    this.sound.playbackRate = rate;
+  }
+
+  getPlaybackRate() {
+    return this.sound.playbackRate;
+  }
+
   /**
    * Returns ready state of the player.
    *

--- a/test/audio-playerSpec.js
+++ b/test/audio-playerSpec.js
@@ -314,6 +314,11 @@ describe('Audio player', () => {
 
   it('should bind and return stopwatch', () => {
     const player = new AudioPlayer();
+    player._player = {
+      sound: {
+        playbackRate: 1
+      }
+    };
     const cb = jasmine.createSpy();
     const fakeWatch = jasmine.createSpy();
     spyOn(Stopwatch, 'default').and.callFake(callback => {
@@ -332,6 +337,9 @@ describe('Audio player', () => {
     spyOn(Stopwatch, 'default').and.callFake(callback => callback(15));
     spyOn(player, 'getDuration').and.returnValue(1);
     player._player = jasmine.createSpyObj('player', ['bindStopwatch']);
+    player._player.sound = {
+      playbackRate: 1
+    };
     player.bindStopwatch(cb);
     expect(cb).toHaveBeenCalledWith(10);
   });
@@ -389,6 +397,21 @@ describe('Audio player', () => {
     player._player = jasmine.createSpyObj('player', ['reset']);
     player.reset();
     expect(player.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('should change the playbackrate of the audio', () => {
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['setPlaybackRate']);
+    player.setPlaybackRate(2);
+    expect(player._player.setPlaybackRate).toHaveBeenCalledTimes(1);
+    expect(player._player.setPlaybackRate).toHaveBeenCalledWith(2);
+  });
+
+  it('should get the playbackrate of the audio', () => {
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['getPlaybackRate']);
+    player.getPlaybackRate();
+    expect(player._player.getPlaybackRate).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/test/cordova-media-playerSpec.js
+++ b/test/cordova-media-playerSpec.js
@@ -290,4 +290,9 @@ describe('Cordova Media Player', () => {
   it('should call the preload method', () => {
     player.preload();
   });
+
+  it('should call the get and set playbackRate methods', () => {
+    player.getPlaybackRate();
+    player.setPlaybackRate(1);
+  });
 });

--- a/test/web-audio-playerSpec.js
+++ b/test/web-audio-playerSpec.js
@@ -383,6 +383,20 @@ describe('WebAudioPlayer', () => {
     expect(result).toEqual(10);
   });
 
+  it('should change playback rate', () => {
+    audioMock.playbackRate = 1;
+    webAudioPlayer = new WebAudioPlayer();
+    webAudioPlayer.setPlaybackRate(2);
+    expect(audioMock.playbackRate).toEqual(2);
+  });
+
+  it('should get the playback rate', () => {
+    audioMock.playbackRate = 2;
+    webAudioPlayer = new WebAudioPlayer();
+    const result = webAudioPlayer.getPlaybackRate(2);
+    expect(result).toEqual(2);
+  });
+
   it('should get playing state', () => {
     audioMock.paused = true;
     webAudioPlayer = new WebAudioPlayer();


### PR DESCRIPTION
Add methods to set and get the playbackrate for html5 audio.
In cordova these are useless methods. The audio player also binds the
stopwatch and factors the playbackrate into the expected duration
of the audio, as this is not done by the HTML5 audio.

Fixes #221 