### PR TITLE
feat(pronunciationchallenge): audio url as separate parameter

### DIFF
--- a/src/administrative-sdk/pronunciation-challenge/pronunciation-challenge.js
+++ b/src/administrative-sdk/pronunciation-challenge/pronunciation-challenge.js
@@ -7,9 +7,11 @@ export default class PronunciationChallenge {
    *
    * @param {?string} id - The pronunciation challenge identifier. If none is given, one is generated.
    * @param {string} transcription - The spoken word or sentence as plain text.
-   * @param {Blob} referenceAudio - The reference audio fragment.
+   * @param {?string} referenceAudioUrl - The reference audio fragment URL. If one is not yet available or audio is
+   * not yet registered to the challenge it can be set to 'null'.
+   * @throws {Error} referenceAudioUrl parameter of type "string|null" is required
    */
-  constructor(id, transcription, referenceAudio) {
+  constructor(id, transcription, referenceAudioUrl = null) {
     if (id && typeof id !== 'string') {
       throw new Error(
         'id parameter of type "string|null" is required');
@@ -28,15 +30,6 @@ export default class PronunciationChallenge {
      * @type {string}
      */
     this.transcription = transcription;
-    if (typeof referenceAudio !== 'object' && referenceAudio) {
-      throw new Error(
-        'referenceAudio parameter of type "Blob" is required');
-    }
-    /**
-     * The reference audio fragment.
-     * @type {Blob}
-     */
-    this.referenceAudio = referenceAudio;
 
     /**
      * The creation date of the challenge entity.
@@ -56,10 +49,14 @@ export default class PronunciationChallenge {
      */
     this.status = null;
 
+    if (referenceAudioUrl !== null && typeof referenceAudioUrl !== 'string') {
+      throw new Error('referenceAudioUrl parameter of type "string|null" is required');
+    }
+
     /**
      * The reference audio fragment as streaming audio link.
      * @type {string}
      */
-    this.referenceAudioUrl = null;
+    this.referenceAudioUrl = referenceAudioUrl;
   }
 }

--- a/test/pronunciation-analysisSpec.js
+++ b/test/pronunciation-analysisSpec.js
@@ -17,6 +17,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
   let fakeResponse;
   let stringDate;
   let controller;
+  let audioUrl;
 
   beforeEach(() => {
     api = new Connection({
@@ -24,6 +25,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
       wsUrl: 'ws://foo.bar',
       oAuth2Token: 'token'
     });
+    audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
     let shouldFireRecord = true;
     RecorderMock = function() {
       this.getAudioSpecs = function() {
@@ -34,7 +36,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
             sampleWidth: 16,
             sampleRate: 48000
           },
-          audioUrl: 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ'
+          audioUrl
         };
       };
       this.hasUserMediaApproval = function() {
@@ -76,7 +78,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
       };
     };
 
-    challenge = new PronunciationChallenge('4', 'foo', new Blob(['a']));
+    challenge = new PronunciationChallenge('4', 'foo', audioUrl);
     recorder = new RecorderMock();
     stringDate = '2014-12-31T23:59:59Z';
     fakeResponse = {
@@ -90,7 +92,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
         sampleWidth: 16,
         sampleRate: 48000
       },
-      audioUrl: 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ'
+      audioUrl
     };
     api._session = new SessionMock();
     spyOn(api._session, 'call').and.callThrough();
@@ -139,7 +141,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
   });
 
   it('should fail streaming when challenge.id is not present', done => {
-    challenge = new PronunciationChallenge('', '', new Blob(['a']));
+    challenge = new PronunciationChallenge('', '', audioUrl);
     controller.startStreamingPronunciationAnalysis(challenge, null)
       .then(() => {
         fail('No result should be returned');
@@ -153,7 +155,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
   it('should fail streaming when recording is already recording', done => {
     recorder.isRecording = () => true;
     api._session = {};
-    challenge = new PronunciationChallenge('1', '4', '', new Blob(['a']));
+    challenge = new PronunciationChallenge('1', '4', '', audioUrl);
     controller.startStreamingPronunciationAnalysis(challenge, recorder)
       .then(() => {
         fail('No result should be returned');
@@ -169,7 +171,7 @@ describe('Pronunciation Analyisis Websocket API interaction test', () => {
     api._analysisId = '5';
     api._session = {};
     controller = new Controller(api);
-    challenge = new PronunciationChallenge('1', '4', '', new Blob(['a']));
+    challenge = new PronunciationChallenge('1', '4', '', audioUrl);
     controller.startStreamingPronunciationAnalysis(challenge, recorder)
       .then(() => {
         fail('No result should be returned');
@@ -794,7 +796,8 @@ describe('PronunciationAnalyses API interaction test', () => {
     const api = new Connection({
       oAuth2Token: 'token'
     });
-    const challenge = new PronunciationChallenge('1', 'test', new Blob());
+    const audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
+    const challenge = new PronunciationChallenge('1', 'test', audioUrl);
     const controller = new Controller(api);
     controller.getPronunciationAnalysis(challenge.id)
       .then(() => {
@@ -810,9 +813,9 @@ describe('PronunciationAnalyses API interaction test', () => {
     const api = new Connection({
       oAuth2Token: 'token'
     });
-    const challenge = new PronunciationChallenge('4', 'test', new Blob());
-    const url = 'https://api.itslanguage.nl/challenges/pronunciation/4/analyses/5';
     const audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
+    const challenge = new PronunciationChallenge('4', 'test', audioUrl);
+    const url = 'https://api.itslanguage.nl/challenges/pronunciation/4/analyses/5';
     const content = {
       id: '5',
       created: '2014-12-31T23:59:59Z',
@@ -848,9 +851,9 @@ describe('PronunciationAnalyses API interaction test', () => {
     const api = new Connection({
       oAuth2Token: 'token'
     });
-    const challenge = new PronunciationChallenge('4', 'test', new Blob());
-    const url = 'https://api.itslanguage.nl/challenges/pronunciation/4/analyses/5';
     const audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
+    const challenge = new PronunciationChallenge('4', 'test', audioUrl);
+    const url = 'https://api.itslanguage.nl/challenges/pronunciation/4/analyses/5';
     const content = {
       id: '5',
       created: '2014-12-31T23:59:59Z',
@@ -916,9 +919,8 @@ describe('PronunciationAnalyses API interaction test', () => {
     const api = new Connection({
       oAuth2Token: 'token'
     });
-
-    const challenge = new PronunciationChallenge('4', 'test', new Blob());
     const audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
+    const challenge = new PronunciationChallenge('4', 'test', audioUrl);
     const content = [{
       id: '5',
       created: '2014-12-31T23:59:59Z',
@@ -998,7 +1000,8 @@ describe('PronunciationAnalyses API interaction test', () => {
     const api = new Connection({
       oAuth2Token: 'token'
     });
-    const challenge = new PronunciationChallenge('', 'test', new Blob());
+    const audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
+    const challenge = new PronunciationChallenge('', 'test', audioUrl);
     const controller = new Controller(api);
     controller.getPronunciationAnalyses(challenge.id, null)
       .then(() => {
@@ -1014,11 +1017,10 @@ describe('PronunciationAnalyses API interaction test', () => {
     const api = new Connection({
       oAuth2Token: 'token'
     });
-
-    const challenge = new PronunciationChallenge('4', 'test', new Blob());
+    const audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
+    const challenge = new PronunciationChallenge('4', 'test', audioUrl);
     const url = 'https://api.itslanguage.nl/challenges/pronunciation/4/analyses?detailed=true';
 
-    const audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
     const content = [{
       id: '5',
       created: '2014-12-31T23:59:59Z',

--- a/test/pronunciation-challengeSpec.js
+++ b/test/pronunciation-challengeSpec.js
@@ -53,6 +53,19 @@ describe('PronunciationChallenge API interaction test', () => {
     url = 'https://api.itslanguage.nl/challenges/pronunciation';
   });
 
+  it('should not create on invalid challenge', done => {
+    [0, '0', {}, [], true, false, null, undefined].map(v => {
+      controller.createPronunciationChallenge(v)
+        .then(() => {
+          fail('An error should be thrown');
+        })
+        .catch(error => {
+          expect(error.message).toEqual('challenge parameter of type "PronunciationChallenge" is required');
+        })
+        .then(done);
+    });
+  });
+
   it('should check for required referenceAudio field', done => {
     const challenge = new PronunciationChallenge('1', 'test', referenceAudioUrl);
     controller.createPronunciationChallenge(challenge, null)

--- a/test/pronunciation-challengeSpec.js
+++ b/test/pronunciation-challengeSpec.js
@@ -13,18 +13,18 @@ describe('PronunciationChallenge object test', () => {
     }).toThrowError('transcription parameter of type "string" is required');
 
     expect(() => {
-      new PronunciationChallenge('hi', '1', '1');
-    }).toThrowError('referenceAudio parameter of type "Blob" is required');
+      new PronunciationChallenge('hi', '1', 0);
+    }).toThrowError('referenceAudioUrl parameter of type "string|null" is required');
   });
 
   it('should instantiate a PronunciationChallenge', () => {
-    const blob = new Blob(['1234567890']);
+    const audioUrl = 'https://api.itslanguage.nl/download/Ysjd7bUGseu8-bsJ';
 
-    const s = new PronunciationChallenge('test', 'hi', blob);
+    const s = new PronunciationChallenge('test', 'hi', audioUrl);
     expect(s).toBeDefined();
     expect(s.id).toBe('test');
     expect(s.transcription).toBe('hi');
-    expect(s.referenceAudio).toBe(blob);
+    expect(s.referenceAudioUrl).toBe(audioUrl);
   });
 
   it('should instantiate a PronunciationChallenge wihtout referenceAudio', () => {
@@ -32,7 +32,7 @@ describe('PronunciationChallenge object test', () => {
     expect(s).toBeDefined();
     expect(s.id).toBe('test');
     expect(s.transcription).toBe('hi');
-    expect(s.referenceAudio).toBeUndefined();
+    expect(s.referenceAudioUrl).toBeNull();
   });
 });
 
@@ -54,26 +54,24 @@ describe('PronunciationChallenge API interaction test', () => {
   });
 
   it('should check for required referenceAudio field', done => {
-    const challenge = new PronunciationChallenge('1', 'test', blob);
-    challenge.referenceAudio = null;
-    controller.createPronunciationChallenge(challenge)
+    const challenge = new PronunciationChallenge('1', 'test', referenceAudioUrl);
+    controller.createPronunciationChallenge(challenge, null)
       .then(() => {
         fail('An error should be thrown');
       })
       .catch(error => {
-        expect(error.message).toEqual('referenceAudio parameter of type "Blob" is required');
+        expect(error.message).toEqual('audioBlob parameter of type "Blob" is required');
       })
       .then(done);
   });
 
   it('should create a new pronunciation challenge through API', done => {
-    const challenge = new PronunciationChallenge('1', 'test', blob);
+    const challenge = new PronunciationChallenge('1', 'test', referenceAudioUrl);
     const content = {
       id: '1',
       created: '2014-12-31T23:59:59Z',
       updated: '2014-12-31T23:59:59Z',
       transcription: 'test',
-      referenceAudio: blob,
       referenceAudioUrl,
       status: 'preparing'
     };
@@ -84,18 +82,16 @@ describe('PronunciationChallenge API interaction test', () => {
       }
     });
     spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
-    controller.createPronunciationChallenge(challenge)
+    controller.createPronunciationChallenge(challenge, blob)
       .then(result => {
         const request = window.fetch.calls.mostRecent().args;
         expect(request[0]).toBe(url);
         expect(request[1].method).toBe('POST');
         expect(request[1].body).toEqual(JSON.stringify(challenge));
         const stringDate = '2014-12-31T23:59:59Z';
-        const outChallenge = new PronunciationChallenge('1', 'test', blob);
+        const outChallenge = new PronunciationChallenge('1', 'test', referenceAudioUrl);
         outChallenge.created = new Date(stringDate);
         outChallenge.updated = new Date(stringDate);
-        outChallenge.referenceAudio = challenge.referenceAudio;
-        outChallenge.referenceAudioUrl = referenceAudioUrl;
         outChallenge.status = 'preparing';
         expect(result).toEqual(outChallenge);
       })
@@ -106,13 +102,12 @@ describe('PronunciationChallenge API interaction test', () => {
   });
 
   it('should create a new pronunciation challenge through API without an id', done => {
-    const challenge = new PronunciationChallenge(null, 'test', blob);
+    const challenge = new PronunciationChallenge(null, 'test', referenceAudioUrl);
     const content = {
       id: '1',
       created: '2014-12-31T23:59:59Z',
       updated: '2014-12-31T23:59:59Z',
       transcription: 'test',
-      referenceAudio: blob,
       referenceAudioUrl,
       status: 'preparing'
     };
@@ -123,18 +118,16 @@ describe('PronunciationChallenge API interaction test', () => {
       }
     });
     spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
-    controller.createPronunciationChallenge(challenge)
+    controller.createPronunciationChallenge(challenge, blob)
       .then(result => {
         const request = window.fetch.calls.mostRecent().args;
         expect(request[0]).toBe(url);
         expect(request[1].method).toBe('POST');
         expect(request[1].body).toEqual(JSON.stringify(challenge));
         const stringDate = '2014-12-31T23:59:59Z';
-        const outChallenge = new PronunciationChallenge('1', 'test', blob);
+        const outChallenge = new PronunciationChallenge('1', 'test', referenceAudioUrl);
         outChallenge.created = new Date(stringDate);
         outChallenge.updated = new Date(stringDate);
-        outChallenge.referenceAudio = challenge.referenceAudio;
-        outChallenge.referenceAudioUrl = referenceAudioUrl;
         outChallenge.status = 'preparing';
         expect(result).toEqual(outChallenge);
       })
@@ -162,7 +155,6 @@ describe('PronunciationChallenge API interaction test', () => {
       created: '2014-12-31T23:59:59Z',
       updated: '2014-12-31T23:59:59Z',
       transcription: 'Hi',
-      referenceAudio: blob,
       referenceAudioUrl,
       status: 'prepared'
     };
@@ -179,10 +171,9 @@ describe('PronunciationChallenge API interaction test', () => {
         expect(request[0]).toBe(url);
         expect(request[1].method).toBe('GET');
         const stringDate = '2014-12-31T23:59:59Z';
-        const challenge = new PronunciationChallenge('4', 'Hi', JSON.parse(JSON.stringify(blob)));
+        const challenge = new PronunciationChallenge('4', 'Hi', referenceAudioUrl);
         challenge.created = new Date(stringDate);
         challenge.updated = new Date(stringDate);
-        challenge.referenceAudioUrl = referenceAudioUrl;
         challenge.status = 'prepared';
         expect(result).toEqual(challenge);
       })
@@ -198,7 +189,6 @@ describe('PronunciationChallenge API interaction test', () => {
       created: '2014-12-31T23:59:59Z',
       updated: '2014-12-31T23:59:59Z',
       transcription: 'Hi',
-      referenceAudio: blob,
       referenceAudioUrl,
       status: 'prepared'
     }];
@@ -215,10 +205,9 @@ describe('PronunciationChallenge API interaction test', () => {
         expect(request[0]).toBe(url);
         expect(request[1].method).toBe('GET');
         const stringDate = '2014-12-31T23:59:59Z';
-        const challenge = new PronunciationChallenge('4', 'Hi', JSON.parse(JSON.stringify(blob)));
+        const challenge = new PronunciationChallenge('4', 'Hi', referenceAudioUrl);
         challenge.created = new Date(stringDate);
         challenge.updated = new Date(stringDate);
-        challenge.referenceAudioUrl = referenceAudioUrl;
         challenge.status = 'prepared';
         expect(result[0]).toEqual(challenge);
         expect(result.length).toBe(1);
@@ -241,7 +230,7 @@ describe('PronunciationChallenge API interaction test', () => {
   });
 
   it('should delete a an existing challenge', done => {
-    const challenge = new PronunciationChallenge('test', 'hi', blob);
+    const challenge = new PronunciationChallenge('test', 'hi', referenceAudioUrl);
     url = 'https://api.itslanguage.nl/challenges/pronunciation/test';
 
     const content =
@@ -271,7 +260,7 @@ describe('PronunciationChallenge API interaction test', () => {
   });
 
   it('should not delete a non existing challenge', done => {
-    const challenge = new PronunciationChallenge('test', 'hi', blob);
+    const challenge = new PronunciationChallenge('test', 'hi', referenceAudioUrl);
     const content = {
       message: 'Validation failed',
       errors: [


### PR DESCRIPTION
Deploy audio as a separate parameter when creating a pronunciationChallenge.
The audio file is not returned by the API, only the download url, so enter
the download url as parameter to the challenge constructor.