### PR TITLE
docs: remove some classes from docs

### DIFF
--- a/src/administrative-sdk/utils/base64-utils.js
+++ b/src/administrative-sdk/utils/base64-utils.js
@@ -1,3 +1,6 @@
+/**
+ * @private
+ */
 export default class Base64Utils {
 
   /**

--- a/src/audio/cordova-media-player.js
+++ b/src/audio/cordova-media-player.js
@@ -11,7 +11,9 @@ device
  * @author d-centralize
  */
 
-
+/**
+ * @private
+ */
 export default class CordovaMediaPlayer {
   /**
    * ITSLanguage CordovaMediaPlayer non-graphical component.

--- a/src/audio/cordova-media-recorder.js
+++ b/src/audio/cordova-media-recorder.js
@@ -11,6 +11,7 @@ Media
  *
  * More information on:
  * https://github.com/apache/cordova-plugin-media/blob/master/doc/index.md
+ * @private
  */
 export default class CordovaMediaRecorder {
   /**

--- a/src/audio/media-recorder.js
+++ b/src/audio/media-recorder.js
@@ -13,6 +13,9 @@
  * https://wiki.mozilla.org/Gecko:MediaRecorder
  *
  */
+/**
+ * @private
+ */
 export default class MediaRecorder {
   /**
    * MediaRecorder.

--- a/src/audio/web-audio-player.js
+++ b/src/audio/web-audio-player.js
@@ -6,6 +6,7 @@
  * @author d-centralize
  *
  * This class fires the same events as the HTML5 Audio does. {@link http://www.w3schools.com/tags/ref_av_dom.asp}
+ * @private
  */
 
 export default class WebAudioPlayer {

--- a/src/audio/web-audio-recorder.js
+++ b/src/audio/web-audio-recorder.js
@@ -1,5 +1,6 @@
 /**
  * WebAudioRecorder.
+ * @private
  */
 export default class WebAudioRecorder {
   /**


### PR DESCRIPTION
Set some classes to private to avoid them showing up in the docs.
The user does not need to know about these internal classes.