### PR TITLE
feat(audioplayers): volume control

### DIFF
--- a/src/audio/audio-player.js
+++ b/src/audio/audio-player.js
@@ -60,6 +60,8 @@ export default class AudioPlayer {
     this._player = this._getBestPlayer(callbacks);
     this._emitter = ee({});
     this._stopwatch = null;
+    this._audioLevel = 1;
+    this._audioMuted = false;
   }
 
   /**
@@ -195,6 +197,7 @@ export default class AudioPlayer {
   load(url, preload, loadedCb) {
     this.reset();
     this._player.load(url, preload, loadedCb);
+    this._audioLevel = 1;
 
     // If preloading is disabled, the 'canplay' event won't be triggered.
     // In that case, fire it manually.
@@ -376,4 +379,61 @@ export default class AudioPlayer {
     });
     return this._stopwatch;
   }
+
+  /**
+   * Sets the audio level of the current loaded audio. Valid values are from 0 (0%) to 1 (100%).
+   *
+   * @param {number} volume - Volume value from 0 to 1.
+   */
+  setAudioVolume(volume) {
+    if (volume !== 0) {
+      this._audioMuted = false;
+    }
+    if (volume === 0) {
+      this._audioMuted = true;
+    }
+    this._player.setAudioVolume(volume);
+  }
+
+  /**
+   * Gets the audio level of the current loaded audio. Valid values are from 0 (0%) to 1 (100%).
+   *
+   * @returns {number} Volume level of the current loaded audio.
+   */
+  getAudioVolume() {
+    return this._player.getAudioVolume();
+  }
+
+  /**
+   * Toggle the current playing audio to be muted or not. If the audio will be muted, the current audio level
+   * is remembered and can be unmuted to continue at this same audio level.
+   */
+  toggleAudioMute() {
+    this.setAudioMute(!this._audioMuted);
+  }
+
+  /**
+   * Manually set the muted state of the current loaded audio.
+   *
+   * @param {boolean} shouldMute - Whether the audio should be muted or unmuted.
+   */
+  setAudioMute(shouldMute) {
+    if (shouldMute) {
+      this._audioLevel = this.getAudioVolume();
+      this.setAudioVolume(0);
+    } else {
+      this.setAudioVolume(this._audioLevel);
+    }
+  }
+
+  /**
+   * Return the muted state of the current loaded audio.
+   *
+   * @returns {boolean} The muted state of the current loaded audio.
+   */
+  isAudioMuted() {
+    return this._audioMuted;
+  }
 }
+
+

--- a/src/audio/cordova-media-player.js
+++ b/src/audio/cordova-media-player.js
@@ -289,4 +289,11 @@ export default class CordovaMediaPlayer {
   isPlaying() {
     return this._isPlaying;
   }
+
+  setAudioVolume(volume) {
+    this.sound.setVolume(volume);
+  }
+
+  getAudioVolume() {
+  }
 }

--- a/src/audio/web-audio-player.js
+++ b/src/audio/web-audio-player.js
@@ -324,4 +324,12 @@ export default class WebAudioPlayer {
     return this.sound.readyState >= this.sound.HAVE_METADATA ||
       this.sound.src && !this.sound.error;
   }
+
+  setAudioVolume(volume) {
+    this.sound.volume = volume;
+  }
+
+  getAudioVolume() {
+    return this.sound.volume;
+  }
 }

--- a/test/audio-playerSpec.js
+++ b/test/audio-playerSpec.js
@@ -413,5 +413,99 @@ describe('Audio player', () => {
     player.getPlaybackRate();
     expect(player._player.getPlaybackRate).toHaveBeenCalledTimes(1);
   });
+
+  it('should set the volume of the audio', () => {
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['setAudioVolume', 'getAudioVolume']);
+    player.setAudioVolume(0.2);
+    expect(player._player.setAudioVolume).toHaveBeenCalledTimes(1);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(0.2);
+    expect(player._audioMuted).toBeFalsy();
+  });
+
+  it('should set the volume of the audio to zero and mute', () => {
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['setAudioVolume', 'getAudioVolume']);
+    player.setAudioVolume(0);
+    expect(player._player.setAudioVolume).toHaveBeenCalledTimes(1);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(0);
+    expect(player._audioMuted).toBeTruthy();
+  });
+
+  it('should get the volume of the audio', () => {
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['setAudioVolume', 'getAudioVolume']);
+    player._player.getAudioVolume.and.returnValue(0.5);
+    const result = player.getAudioVolume(0.2);
+    expect(player._player.getAudioVolume).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(0.5);
+  });
+
+  it('should set the mute of the audio true', () => {
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['setAudioVolume', 'getAudioVolume']);
+    player.setAudioMute(true);
+    expect(player._player.setAudioVolume).toHaveBeenCalledTimes(1);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(0);
+    expect(player._audioMuted).toBeTruthy();
+  });
+
+  it('should unmute the audio after muting', () => {
+    const player = new AudioPlayer();
+    spyOn(player, 'toggleAudioMute').and.callThrough();
+    player._player = jasmine.createSpyObj('player', ['setAudioVolume', 'getAudioVolume']);
+    player._player.getAudioVolume.and.returnValue(0.5);
+    player.setAudioMute(true);
+    expect(player._audioMuted).toBeTruthy();
+
+    player._player.getAudioVolume.and.returnValue(0);
+    player.setAudioMute(false);
+    expect(player._audioMuted).toBeFalsy();
+
+    expect(player._player.setAudioVolume).toHaveBeenCalledTimes(2);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(0);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(0.5);
+  });
+
+  it('should unmute the audio with a previous changed audiolevel', () => {
+    const audioLevel = 0.5;
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['setAudioVolume', 'getAudioVolume']);
+    player._player.getAudioVolume.and.returnValue(audioLevel);
+    player.setAudioVolume(audioLevel);
+    player.setAudioMute(true);
+    player.setAudioMute(false);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(0);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(audioLevel);
+    expect(player._player.setAudioVolume).toHaveBeenCalledTimes(3);
+  });
+
+  it('should get the _audioMuted property', () => {
+    const player = new AudioPlayer();
+    const result = player.isAudioMuted();
+    expect(result).toBeFalsy();
+  });
+
+  it('should get the _audioMuted property after muting', () => {
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['setAudioVolume', 'getAudioVolume']);
+    player._player.getAudioVolume.and.returnValue(0.5);
+    player.setAudioMute(true);
+    const result = player.isAudioMuted();
+    expect(result).toBeTruthy();
+  });
+
+  it('should toggle the mute state on and off', () => {
+    const player = new AudioPlayer();
+    player._player = jasmine.createSpyObj('player', ['setAudioVolume', 'getAudioVolume']);
+    player._player.getAudioVolume.and.returnValue(1);
+    player.toggleAudioMute();
+    player._player.getAudioVolume.and.returnValue(0);
+    expect(player._player.setAudioVolume).toHaveBeenCalledTimes(1);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(0);
+    player.toggleAudioMute();
+    expect(player._player.setAudioVolume).toHaveBeenCalledTimes(2);
+    expect(player._player.setAudioVolume).toHaveBeenCalledWith(1);
+  });
 });
 

--- a/test/cordova-media-playerSpec.js
+++ b/test/cordova-media-playerSpec.js
@@ -295,4 +295,22 @@ describe('Cordova Media Player', () => {
     player.getPlaybackRate();
     player.setPlaybackRate(1);
   });
+
+  it('should set the audio volume', () => {
+    player.sound = {
+      setVolume: jasmine.createSpy()
+    };
+    player.setAudioVolume(0.5);
+    expect(player.sound.setVolume).toHaveBeenCalledWith(0.5);
+
+    player.setAudioVolume(0);
+    expect(player.sound.setVolume).toHaveBeenCalledWith(0);
+
+    player.setAudioVolume(1);
+    expect(player.sound.setVolume).toHaveBeenCalledWith(1);
+  });
+
+  it('should call the get audio volume', () => {
+    player.getAudioVolume();
+  });
 });

--- a/test/web-audio-playerSpec.js
+++ b/test/web-audio-playerSpec.js
@@ -474,4 +474,28 @@ describe('WebAudioPlayer', () => {
     result = webAudioPlayer.canPlay();
     expect(result).toBeTruthy();
   });
+
+  it('should set the audio volume', () => {
+    webAudioPlayer = new WebAudioPlayer();
+    webAudioPlayer.setAudioVolume(0.5);
+    expect(audioMock.volume).toEqual(0.5);
+
+    webAudioPlayer.setAudioVolume(0);
+    expect(audioMock.volume).toEqual(0);
+
+    webAudioPlayer.setAudioVolume(1);
+    expect(audioMock.volume).toEqual(1);
+  });
+
+  it('should get the audio volume', () => {
+    webAudioPlayer = new WebAudioPlayer();
+    audioMock.volume = 0.5;
+    expect(webAudioPlayer.getAudioVolume()).toEqual(0.5);
+
+    audioMock.volume = 0;
+    expect(webAudioPlayer.getAudioVolume()).toEqual(0);
+
+    audioMock.volume = 1;
+    expect(webAudioPlayer.getAudioVolume()).toEqual(1);
+  });
 });


### PR DESCRIPTION
Add methods for volume control. Set muted, togglemute, set and get audio
volume and get muted state. Volume level cannot be gotten from the cordova
media as that is not implemented by the Cordova Media class.

Fixes #238 