### PR TITLE
fix(webaudioplayer): log correct playing time

### DIFF
--- a/src/audio/web-audio-player.js
+++ b/src/audio/web-audio-player.js
@@ -171,8 +171,8 @@ export default class WebAudioPlayer {
         this.sound.currentTime = position;
       }
     }
-    console.debug('Start playing from position: ' + this.sound.currentTime);
     this.sound.play();
+    console.debug('Start playing from position: ' + this.sound.currentTime);
   }
 
   /**


### PR DESCRIPTION
Switch logging statement to after the audio starts playing so it logs the correct time.
Fixes #241 