### PR TITLE
chore: add .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+/build/
+/coverage/
+/esdoc/
+/node_modules/


### PR DESCRIPTION
ESLint was also used to check generated JavaScript files, which don't
follow the style guide.