### PR TITLE
fix(audio-recorder): don't raise concerns on stopped recorder

### DIFF
--- a/src/audio/audio-recorder.js
+++ b/src/audio/audio-recorder.js
@@ -342,7 +342,6 @@ export default class AudioRecorder {
    */
   stop(forced) {
     if (!this._recorder.isRecording()) {
-      console.error('Recorder was already stopped.');
       return;
     }
     this._recorder.stop();


### PR DESCRIPTION
When a record timeout is triggered, the stop function of a recorder
is usually called in the timer tick handler. Sometimes, a new tick
might be triggered sooner than the recorder is stopped. Not a
problem, so don't raise concerns.