### PR TITLE
refactor(Connection): generate scope in `getUserAuth`

### DIFF
--- a/src/administrative-sdk/connection/connection-controller.js
+++ b/src/administrative-sdk/connection/connection-controller.js
@@ -321,7 +321,7 @@ export default class Connection {
       '&password=' + basicAuth.credentials;
 
     if (scopes) {
-      formData += '&scopes=' + scopes;
+      formData += '&scope=' + scopes;
     }
 
     const options = {

--- a/src/administrative-sdk/connection/connection-controller.js
+++ b/src/administrative-sdk/connection/connection-controller.js
@@ -306,31 +306,30 @@ export default class Connection {
    * Ask the server for an OAuth2 token.
    *
    * @param {BasicAuth} basicAuth - Basic Auth to obtain credentials from.
-   * @param {string} organisationId - Id of the organisation to request a token for.
-   * @param {string} userId - Id of the user to request a token for.
+   * @param {string} [scopes] - The scopes which should be availible for the requested token.
    * @returns {Promise} Promise containing a access_token, token_type and scope.
    * @throws {Promise.<Error>} If the server returned an error.
    */
-  getOauth2Token(basicAuth, organisationId, userId) {
+  getOauth2Token(basicAuth, scopes) {
     const url = this._settings.apiUrl + '/tokens';
-    let scopes = 'tenant/' + basicAuth.tenantId;
-    if (organisationId) {
-      scopes += '/organisation/' + organisationId;
-    }
-    if (organisationId && userId) {
-      scopes += '/user/' + userId;
-    }
+
     const headers = new Headers();
-    headers.append('Content-Type',
-      'application/x-www-form-urlencoded; charset=utf8');
-    const formData = 'grant_type=password&scope=' + scopes +
+    headers.append('Content-Type', 'application/x-www-form-urlencoded; charset=utf8');
+
+    let formData = 'grant_type=password' +
       '&username=' + basicAuth.principal +
       '&password=' + basicAuth.credentials;
+
+    if (scopes) {
+      formData += '&scopes=' + scopes;
+    }
+
     const options = {
       method: 'POST',
       headers,
       body: formData
     };
+
     return fetch(url, options)
       .then(response =>
         response.json()
@@ -347,10 +346,20 @@ export default class Connection {
   /**
    * Request authentication for a {@link User}. The basicAuth now contains the user's username and password.
    *
+   * This method also generates the appropriate scope for the given params.
+   *
    * @param {BasicAuth} basicAuth - Basic Auth to obtain credentials from.
    * @param {string} organisationId - Id of the organisation this user is part of.
    */
   getUserAuth(basicAuth, organisationId) {
-    return this.getOauth2Token(basicAuth, organisationId, basicAuth.principal);
+    let scopes = 'tenant/' + basicAuth.tenantId;
+    if (organisationId) {
+      scopes += '/organisation/' + organisationId;
+      if (basicAuth.principal) {
+        scopes += '/user/' + basicAuth.principal;
+      }
+    }
+
+    return this.getOauth2Token(basicAuth, scopes);
   }
 }

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -378,14 +378,15 @@ describe('Connection', () => {
       const basicAuth = new BasicAuth('4', 'principal', 'credentials');
       spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
       url += '/tokens';
-      api.getOauth2Token(basicAuth, 'fb', 'dummy')
+      api.getOauth2Token(basicAuth, 'tenant/' + basicAuth.tenantId)
         .then(result => {
           const request = window.fetch.calls.mostRecent().args;
           expect(request[0]).toBe(url);
-          expect(request[1].body).toEqual('grant_type=password&' +
-            'scope=tenant/' + basicAuth.tenantId +
-            '/organisation/fb/user/dummy&username=' + basicAuth.principal +
-            '&password=' + basicAuth.credentials);
+          expect(request[1].body).toEqual(
+            'grant_type=password' +
+            '&username=' + basicAuth.principal +
+            '&password=' + basicAuth.credentials +
+            '&scopes=tenant/' + basicAuth.tenantId);
           expect(result.token_type).toEqual('Bearer');
           expect(result.access_token).toEqual('2b198b6bc87db1bdb');
           expect(result.scope).toEqual('tenant/4');
@@ -411,14 +412,14 @@ describe('Connection', () => {
       });
       const basicAuth = new BasicAuth('4', 'principal', 'credentials');
       spyOn(window, 'fetch').and.returnValue(Promise.resolve(fakeResponse));
-      api.getOauth2Token(basicAuth, 'fb')
+      api.getOauth2Token(basicAuth, 'tenant/' + basicAuth.tenantId + '/organisation/fb')
         .then(result => {
           const request = window.fetch.calls.mostRecent().args;
           expect(request[0]).toBe(url);
-          expect(request[1].body).toEqual('grant_type=password&' +
-            'scope=tenant/' + basicAuth.tenantId +
-            '/organisation/fb&username=' + basicAuth.principal +
-            '&password=' + basicAuth.credentials);
+          expect(request[1].body).toEqual('grant_type=password' +
+            '&username=' + basicAuth.principal +
+            '&password=' + basicAuth.credentials +
+            '&scopes=tenant/' + basicAuth.tenantId + '/organisation/fb');
           expect(result.token_type).toEqual('Bearer');
           expect(result.access_token).toEqual('2b198b6bc87db1bdb');
           expect(result.scope).toEqual('tenant/4');
@@ -447,8 +448,7 @@ describe('Connection', () => {
         .then(result => {
           const request = window.fetch.calls.mostRecent().args;
           expect(request[0]).toBe(url);
-          expect(request[1].body).toEqual('grant_type=password&' +
-            'scope=tenant/' + basicAuth.tenantId +
+          expect(request[1].body).toEqual('grant_type=password' +
             '&username=' + basicAuth.principal +
             '&password=' + basicAuth.credentials);
           expect(result.token_type).toEqual('Bearer');
@@ -479,8 +479,7 @@ describe('Connection', () => {
           expect(error.error).toEqual('invalid_scope');
           const request = window.fetch.calls.mostRecent().args;
           expect(request[0]).toBe(url);
-          expect(request[1].body).toEqual('grant_type=password&' +
-            'scope=tenant/' + basicAuth.tenantId +
+          expect(request[1].body).toEqual('grant_type=password' +
             '&username=' + basicAuth.principal +
             '&password=' + basicAuth.credentials);
         })
@@ -489,10 +488,23 @@ describe('Connection', () => {
 
     it('should call the oauth2 method with the right parameters when requesting a userauth', () => {
       spyOn(api, 'getOauth2Token');
-      const basicAuth = new BasicAuth('4', 'principes', 'credentials');
+      const basicAuth = new BasicAuth('tenantID', 'username', 'credentials');
       api.getUserAuth(basicAuth, 'org123');
       expect(api.getOauth2Token).toHaveBeenCalledTimes(1);
-      expect(api.getOauth2Token).toHaveBeenCalledWith(basicAuth, 'org123', basicAuth.principal);
+      expect(api.getOauth2Token).toHaveBeenCalledWith(basicAuth, 'tenant/tenantID/organisation/org123/user/username');
+    });
+
+    it('should call the oauth2 method with the appropriate scope', () => {
+      spyOn(api, 'getOauth2Token');
+      const basicAuth = new BasicAuth('tenantID', 'username', 'credentials');
+      const userlessBasicAuth = new BasicAuth('tenantID', undefined, 'credentials');
+
+      api.getUserAuth(userlessBasicAuth, 'org123');
+      api.getUserAuth(basicAuth);
+
+      expect(api.getOauth2Token).toHaveBeenCalledTimes(2);
+      expect(api.getOauth2Token).toHaveBeenCalledWith(basicAuth, 'tenant/tenantID');
+      expect(api.getOauth2Token).toHaveBeenCalledWith(userlessBasicAuth, 'tenant/tenantID/organisation/org123');
     });
   });
 

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -386,7 +386,7 @@ describe('Connection', () => {
             'grant_type=password' +
             '&username=' + basicAuth.principal +
             '&password=' + basicAuth.credentials +
-            '&scopes=tenant/' + basicAuth.tenantId);
+            '&scope=tenant/' + basicAuth.tenantId);
           expect(result.token_type).toEqual('Bearer');
           expect(result.access_token).toEqual('2b198b6bc87db1bdb');
           expect(result.scope).toEqual('tenant/4');
@@ -419,7 +419,7 @@ describe('Connection', () => {
           expect(request[1].body).toEqual('grant_type=password' +
             '&username=' + basicAuth.principal +
             '&password=' + basicAuth.credentials +
-            '&scopes=tenant/' + basicAuth.tenantId + '/organisation/fb');
+            '&scope=tenant/' + basicAuth.tenantId + '/organisation/fb');
           expect(result.token_type).toEqual('Bearer');
           expect(result.access_token).toEqual('2b198b6bc87db1bdb');
           expect(result.scope).toEqual('tenant/4');


### PR DESCRIPTION
Prevent `getOauth2Token` from doing more than its name suggests. Instead
of generating a scope, accept a scope. When no scope is available, don't
set the `scopes` param.