### PR TITLE
fix(VolumeMeter): be able to break the analyzing loop

### DIFF
--- a/src/audio/audio-tools.js
+++ b/src/audio/audio-tools.js
@@ -48,6 +48,7 @@ export default class VolumeMeter {
   constructor(audioContext, inputStream) {
     this.audioContext = audioContext;
     this.stream = inputStream;
+    this.willAnimate = true;
   }
 
 
@@ -100,9 +101,7 @@ export default class VolumeMeter {
     const volumeIndicationCallback = this.volumeIndicationCallback;
     const volumeIndicationCallbackArgs = this.volumeIndicationCallbackArgs;
     const analyserNode = this.analyserNode;
-    const willAnimate = this.willAnimate = {
-      anim: true
-    };
+    const volumeMeter = this;
     let skippedCallbacks = 0;
     let lastVolume = -1;
 
@@ -126,7 +125,7 @@ export default class VolumeMeter {
       analyserNode.getByteFrequencyData(freqByteData);
       let averageVolume = VolumeMeter._getAverageVolume(freqByteData);
 
-      if (willAnimate.anim) {
+      if (volumeMeter.willAnimate) {
         requestAnimationFrame(animloop);
       } else {
         // Stop animating, provide callback with zero volume so the
@@ -164,6 +163,13 @@ export default class VolumeMeter {
    * Stop calculating the volume.
    */
   stopAnalyser() {
-    this.willAnimate.anim = false;
+    this.willAnimate = false;
+  }
+
+  /**
+   * Start calculating the volume.
+   */
+  resumeAnalyser() {
+    this.willAnimate = true;
   }
 }

--- a/test/audio-toolsSpec.js
+++ b/test/audio-toolsSpec.js
@@ -171,8 +171,8 @@ describe('Audio tools', () => {
     meter.volumeIndicationCallback = [cb, cb, cb, cb, cb, cb];
     spyOn(VolumeMeter, '_getAverageVolume').and.returnValue(5);
     spyOn(window, 'requestAnimationFrame').and.callFake(animloop => {
-      meter.willAnimate.anim = false;
-      if (meter.willAnimate.anim === false) {
+      meter.willAnimate = false;
+      if (meter.willAnimate === false) {
         animloop();
       }
     });
@@ -184,12 +184,21 @@ describe('Audio tools', () => {
 
   it('should stop analyzing', () => {
     const meter = new VolumeMeter();
-    meter.willAnimate = {anim: false};
-    expect(meter.willAnimate.anim).toBeFalsy();
-    meter.willAnimate.anim = true;
-    expect(meter.willAnimate.anim).toBeTruthy();
+    meter.willAnimate = false;
+    expect(meter.willAnimate).toBeFalsy();
+    meter.willAnimate = true;
+    expect(meter.willAnimate).toBeTruthy();
     meter.stopAnalyser();
-    expect(meter.willAnimate.anim).toBeFalsy();
+    expect(meter.willAnimate).toBeFalsy();
+  });
+
+  it('should resume analyzing', () => {
+    const meter = new VolumeMeter();
+    expect(meter.willAnimate).toBeTruthy();
+    meter.stopAnalyser();
+    expect(meter.willAnimate).toBeFalsy();
+    meter.resumeAnalyser();
+    expect(meter.willAnimate).toBeTruthy();
   });
 
   it('should generate a wave file', () => {


### PR DESCRIPTION
The animation loop somehow could not break out of its loop when
needed. By taking another approach to access the value for allowing
the loop ('willAnimate') things got better.

Besides setting the analyzer to stop also a resume function has been
added to be able to reuse the VolumeMeter component.