### PR TITLE
fix(progress): allow to fetch progress for a group

### DIFF
--- a/src/administrative-sdk/administrative-sdk.js
+++ b/src/administrative-sdk/administrative-sdk.js
@@ -524,12 +524,15 @@ export default class AdministrativeSDK {
    * from the OAuth2 scope. The progress wil be returned for the current user. If a user is eligible
    * to see the progress of more user, that progress is returned as well.
    *
+   * It is also possible to obtain the progress for the members of a given group.
+   *
    * @param {string} categoryId - Specify a Category identifier.
+   * @param {string} [groupId] - Optionally specify the group identifier.
    * @returns {Promise.<Progress[]>} Array of Progress.
    * @throws {Promise.<Error>} categoryId parameter of type "string" is required.
    * @throws {Promise.<Error>} If the server returned an error.
    */
-  getProgress(categoryId) {
-    return this._progressController.getProgress(categoryId);
+  getProgress(categoryId, groupId) {
+    return this._progressController.getProgress(categoryId, groupId);
   }
 }

--- a/test/administrative-sdkSpec.js
+++ b/test/administrative-sdkSpec.js
@@ -97,7 +97,8 @@ describe('Administrative SDK', () => {
     sdk.getRole(1);
     sdk.getProfile(1);
     sdk.getProfiles();
-    sdk.getProgress(1);
+    sdk.getProgress('category_id');
+    sdk.getProgress('category_id', 'group_id');
     sdk.createCategory(1);
     sdk.getCategory(1);
     sdk.getCategoriesWithParent(1);
@@ -157,6 +158,7 @@ describe('Administrative SDK', () => {
     expect(fakeProfileController.getProfile).toHaveBeenCalledWith(1);
     expect(fakeProfileController.getProfiles).toHaveBeenCalledWith();
 
-    expect(fakeProgressController.getProgress).toHaveBeenCalledWith(1);
+    expect(fakeProgressController.getProgress).toHaveBeenCalledWith('category_id', undefined);
+    expect(fakeProgressController.getProgress).toHaveBeenCalledWith('category_id', 'group_id');
   });
 });


### PR DESCRIPTION
`ProgressController.getProgress` allows for an optional `groupId`
parameter. Also expose this through the `AdministrativeSdk` so it can be
actually used.