### PR TITLE
fix: make the correct token request

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -55,6 +55,8 @@ export function assembleScope(tenant, organisation, user) {
  *
  * @returns {Promise} - A promise which will resolve if the authentication
  *                      concluded successfully, it'll reject in any other case.
+ *                      It resolves with the response body of the token
+ *                      request.
  */
 export function authenticate(username, password, scope) {
   const body = new URLSearchParams();
@@ -67,8 +69,9 @@ export function authenticate(username, password, scope) {
     body.set('scope', scope);
   }
 
-  return request('POST', '/token', body)
+  return request('POST', '/tokens', body)
     .then(result => {
       updateSettings({authorizationToken: result.access_token});
+      return result;
     });
 }

--- a/src/api/auth.spec.js
+++ b/src/api/auth.spec.js
@@ -51,7 +51,7 @@ describe('authenticate', () => {
     auth.authenticate('foo', 'bar', 'this/is/not/a/valid/scope')
       .then(() => {
         const requestCall = requestSpy.calls.mostRecent();
-        expect(requestCall.args).toEqual(['POST', '/token', expectedBody]);
+        expect(requestCall.args).toEqual(['POST', '/tokens', expectedBody]);
         expect(updateSettingsSpy).toHaveBeenCalledWith({authorizationToken: 'token'});
         done();
       }, fail);
@@ -68,7 +68,7 @@ describe('authenticate', () => {
     auth.authenticate('foo', 'bar')
       .then(() => {
         const requestCall = requestSpy.calls.mostRecent();
-        expect(requestCall.args).toEqual(['POST', '/token', expectedBody]);
+        expect(requestCall.args).toEqual(['POST', '/tokens', expectedBody]);
         expect(updateSettingsSpy).toHaveBeenCalledWith({authorizationToken: 'token'});
         done();
       }, fail);


### PR DESCRIPTION
The response body is currently used to also store the token for later usage (i.e. store in localStorage) Also `/token` should have been `/tokens`.

Closes: #289
Fixes: #288