### PR TITLE
chore: proudly display the travis results

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Build JavaScript applications for the ITSLanguage platform.
 
+[![Build Status](https://travis-ci.org/itslanguage/itslanguage-js.svg?branch=next)](https://travis-ci.org/itslanguage/itslanguage-js)
+
 ## Getting started
 
 Adding ITSLanguage into your JavaScript project is as easy as:


### PR DESCRIPTION
Display the build result like any true open-source project does to be
more transparent about the project status.