### PR TITLE
chore: properly babelify the source

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,10 @@
 {
-  "presets": [ ["es2015", {"loose": true}] ]
+  "presets": [
+    [
+      "es2015",
+      {
+        "modules": "umd"
+      }
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "concurrently 'eslint .' 'karma start --single-run --color'",
     "esdoc": "esdoc -c esdoc.json",
-    "babelify": "babel src --out-dir build --source-maps inline && cp package.json README.md build/",
+    "build": "babel src --ignore '**/*.spec.js' --out-dir build --source-maps inline && cp package.json README.md build/",
     "clearbuild": "rm -rf build/"
   },
   "author": "ITSLanguage (https://www.itslanguage.nl) <support@d-centralize.nl>",


### PR DESCRIPTION
UMD seems to be the proper way to expose data; all other forms provide a
couple of quirks; such as common.js (the default of babel) which only
allows you to import exposed objects when you specify the file which
exposes it, including the index.js of a module (e.g.
`import {a} from 'foo/bar/index.js';`). UMD doesn't require this.

Also rename the `babelify` npm script to `build`; because that is a more
sane thing to do.

And while we are at it: ignore the tests which now live next to the source 
files.