### PR TITLE
fix: add audio trim for pronunciation

### DIFF
--- a/src/api/challenges/pronunciation/analysis.js
+++ b/src/api/challenges/pronunciation/analysis.js
@@ -33,7 +33,7 @@ export function getPronunciationAnalysisById(challengeId, analysisId) {
  * @returns {Promise|Promise.<*>} - The result will hold the ID for the analysis.
  */
 export function preparePronunciationAnalysis() {
-  return makeWebsocketCall('pronunciation.init_analysis');
+  return makeWebsocketCall('pronunciation.init_analysis', {kwargs: {trimStart: 0.1, trimEnd: 0.05}});
 }
 
 /**
@@ -48,7 +48,7 @@ export function prepareAnalysisChallenge(analysisId, challengeId) {
 }
 
 /**
- * A Pronunciaion Challange could hold an alignment allready. If not so
+ * A Pronunciation Challenge could hold an alignment already. If not,
  * this function will instruct the backend to create the alignment and
  * return it to the client.
  *


### PR DESCRIPTION
To prevent a noticeable mouse click on recording start, use 100ms of
trimming at the beginning and 50ms out of safety, at the end.
A click at the beginning can disturb analysis a lot.