### PR TITLE
Resend header after pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Feedback API.
 - WebAudio Player supports pause now.
 - WebAudio Player supports volume now.
+- Recorder resend header at resume.
 
 ## [3.1.1]
 ### Added

--- a/src/api/utils/audio-over-socket.js
+++ b/src/api/utils/audio-over-socket.js
@@ -73,16 +73,16 @@ export function registerStreamForRecorder(recorder, rpcName) {
     const {audioParameters: {channels, sampleRate}} = recorder.getAudioSpecs();
     const headerArrBuff = createWAVEHeader(channels, sampleRate);
     const header = Array.from(new Uint8Array(headerArrBuff));
-    let sentHeader = true;
+    let sendHeader = true;
 
     if (details.progress) {
       // Listen for recording events.
       recorder.addEventListener('dataavailable', chuck => {
-        if (sentHeader) {
+        if (sendHeader) {
           // Sent the empty wave header first, this is needed
           // for containerized WAVE files.
           details.progress([header]);
-          sentHeader = false;
+          sendHeader = false;
         }
 
         // Send the data chunks to the backend! Whoop whoop!
@@ -101,7 +101,7 @@ export function registerStreamForRecorder(recorder, rpcName) {
       // In case of a pause, make sure next chunk of data will
       // get the header (again).
       recorder.addEventListener('paused', () => {
-        sentHeader = true;
+        sendHeader = true;
       });
     }
 

--- a/src/api/utils/audio-over-socket.js
+++ b/src/api/utils/audio-over-socket.js
@@ -58,6 +58,10 @@ export function registerStreamForRecorder(recorder, rpcName) {
    * we need to prepend our raw data with a WAVE file header. We do this as first step if data
    * becomes available.
    *
+   * When sending audio gets paused, which will be the case for the pause and resume functionality,
+   * we will resend the header after resuming. The API docs cover the need for this. Check there for
+   * more information.
+   *
    * @see https://github.com/crossbario/autobahn-js/blob/master/doc/reference.md#register
    * @see https://github.com/crossbario/autobahn-js/blob/master/doc/reference.md#progressive-results
    *


### PR DESCRIPTION
As required by API docs, when we pause the recorder we must also resend the WAVE header on resume.