### PR TITLE
Fix content type header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+## [v4.0.1] - 2019-02-11
+
+### Fixed
+
+- Removed adding of the Content-Type header when not needed to add it.
+
 ## [v4.0.0] - 2018-12-12
 
 ### Changed
@@ -64,7 +70,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Changed the getUserAuth and getOAuth2Token to use the new API auth functions.
 
 
-[Unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v4.0.1...HEAD
+[v4.0.0]: https://github.com/itslanguage/itslanguage-js/compare/v4.0.0...v4.0.1
 [v4.0.0]: https://github.com/itslanguage/itslanguage-js/compare/v3.1.2...v4.0.0
 [v3.1.2]: https://github.com/itslanguage/itslanguage-js/compare/v3.1.1...v3.1.2
 [v3.1.1]: https://github.com/itslanguage/itslanguage-js/compare/v3.1.0...v3.1.1

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+## [v4.0.1] - 2019-02-11
+
+### Fixed
+
+- Removed adding of the Content-Type header when not needed to add it.
+
 ## [v4.0.0] - 2018-12-12
 
 ### Added
 
 - API as package, available through `@itslanguage/api`
 
-[Unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v4.0.1...HEAD
+[v4.0.1]: https://github.com/itslanguage/itslanguage-js/compare/v4.0.0...v4.0.1
 [v4.0.0]: https://github.com/itslanguage/itslanguage-js/compare/v3.1.2...v4.0.0

--- a/packages/api/communication/index.js
+++ b/packages/api/communication/index.js
@@ -104,9 +104,7 @@ function handleResponse(response) {
 export function request(method, url, body, headers) {
   const requestHeaders = headers || new Headers();
 
-  // Default to 'text/plain'.
   let requestBody = body;
-  requestHeaders.set('Content-Type', 'text/plain');
 
   // In case of (any) object-type
   if (!(body instanceof URLSearchParams || body instanceof FormData) && body instanceof Object) {
@@ -118,12 +116,6 @@ export function request(method, url, body, headers) {
   if (body instanceof URLSearchParams) {
     requestHeaders.set('Content-Type', 'application/x-www-form-urlencoded');
     requestBody = body.toString();
-  }
-
-  // In case of FormData
-  // Note that we only need to (re)set the content-type!
-  if (body instanceof FormData) {
-    requestHeaders.set('Content-Type', 'multipart/form-data');
   }
 
   // Prepend the url with the set url or use it complete when there was no url set.


### PR DESCRIPTION
There was an error in the request for posting to an URL with FormData.
By "forcing" the `Content-Type: multipart/form-data` header we omitted
the needed boundary information. The browser and/or some NodeJS process
will set this automatically when you try to post FormData: so there is
no need to specify it here this way.

Once merged a new version can be made (v4.0.1 for API).