### PR TITLE
Add non-streaming recognise option

### DIFF
--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
-## [v4.0.1] - 2019-02-11
+## [v4.0.1] - 2018-12-17
 
-### Fixed
+### Added
 
-- Removed adding of the Content-Type header when not needed to add it.
+- Function to take Choice Recognition without streaming.
 
 ## [v4.0.0] - 2018-12-12
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itslanguage/api",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The JavaScript API SDK for ITSLanguage.",
   "author": "ITSLanguage (https://www.itslanguage.nl) <support@itslanguage.nl>",
   "contributors": [


### PR DESCRIPTION
Streaming only works on our "older" backend. Since v4 this changed to streaming. We do have a couple of situations where we need the old streaming variant thus this is added in this PR.

This PR also prepares the v4.0.1 tag release for this.