### PR TITLE
Fix recorder get settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+## [v4.2.2] - 2019-08-13
+
+### Fixed
+
+- `recorder`
+  - The `recorder.getAudioSpecs()` was returning some hard-coded values that
+    where not true on some devices. If the recorded and processed audio sounded
+    like it was speedup: this was why.
+
 ## [v4.2.1] - 2019-06-21
 
 ### Changed
@@ -118,7 +127,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Improve README.md documentation.
 - Changed the getUserAuth and getOAuth2Token to use the new API auth functions.
 
-[unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v4.2.1...HEAD
+[unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v4.2.2...HEAD
+[v4.2.2]: https://github.com/itslanguage/itslanguage-js/compare/v4.2.1...v4.2.2
 [v4.2.1]: https://github.com/itslanguage/itslanguage-js/compare/v4.2.0...v4.2.1
 [v4.2.0]: https://github.com/itslanguage/itslanguage-js/compare/v4.1.0...v4.2.0
 [v4.1.0]: https://github.com/itslanguage/itslanguage-js/compare/v4.0.2...v4.1.0

--- a/packages/recorder/index.js
+++ b/packages/recorder/index.js
@@ -5,10 +5,14 @@
 import MediaRecorder from 'audio-recorder-polyfill';
 import AmplitudePlugin from './plugins/amplitude';
 
-export const DEFAULT_AUDIO_FORMAT = 'audio/wave';
+const AudioContext = window.AudioContext || window.webkitAudioContext;
+const audioContext = new AudioContext();
+const BYTES_PER_SAMPLE = 2;
+
+export const DEFAULT_AUDIO_FORMAT = 'audio/wav';
 export const DEFAULT_CHANNELS = 1;
-export const DEFAULT_SAMPLE_WIDTH = 16;
-export const DEFAULT_SAMPLE_RATE = 48000;
+export const DEFAULT_SAMPLE_WIDTH = 8 * BYTES_PER_SAMPLE;
+export const DEFAULT_SAMPLE_RATE = audioContext.sampleRate;
 
 /**
  * Override or set the MediaRecorder to the window object.
@@ -71,7 +75,7 @@ export function createRecorder(
 
   // We need to add a function "getAudioSpecs" to be compliant with the itslanguage backend...
   recorder.getAudioSpecs = () => ({
-    audioFormat: DEFAULT_AUDIO_FORMAT,
+    audioFormat: recorder.mimeType || DEFAULT_AUDIO_FORMAT,
     audioParameters: {
       channels: DEFAULT_CHANNELS,
       sampleWidth: DEFAULT_SAMPLE_WIDTH,

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itslanguage/recorder",
-  "version": "4.2.0",
+  "version": "4.2.2",
   "description": "JavaScript Recorder based on MediaRecorder from ITSLanguage.",
   "author": "ITSLanguage (https://www.itslanguage.nl) <support@itslanguage.nl>",
   "contributors": [


### PR DESCRIPTION
The `recorder.getAudioSpecs()` was returning some hard-coded values that where not true on some devices. If the recorded and processed audio sounded like it was speedup: this was why.