### PR TITLE
Prepare v5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - `api`, `recorder`, `player`, `examples`, `sdk`
   - Bumped used package versions.
   - Upgraded yarn.lock file.
+  - Set core-js@3 as peerDependency.
 - `recorder`
   - Allow the default browser media types for recording, not just `audio/wav`.
     This can be done through the `mimeType` param on the `createRecorder`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+## [v5.0.0] - 2019-08-29
+
 ### Changed
 
 - `api`, `recorder`, `player`, `examples`, `sdk`
@@ -157,7 +159,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Improve README.md documentation.
 - Changed the getUserAuth and getOAuth2Token to use the new API auth functions.
 
-[unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v4.2.2...HEAD
+[unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v5.0.0...HEAD
+[v5.0.0]: https://github.com/itslanguage/itslanguage-js/compare/v4.2.2...v5.0.0
 [v4.2.2]: https://github.com/itslanguage/itslanguage-js/compare/v4.2.1...v4.2.2
 [v4.2.1]: https://github.com/itslanguage/itslanguage-js/compare/v4.2.0...v4.2.1
 [v4.2.0]: https://github.com/itslanguage/itslanguage-js/compare/v4.1.0...v4.2.0

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We do recommend usage with a package manager like [npm] or [yarn] though.
 <html>
   <head>
     <title>Some page title</title>
-    <script src="https://unpkg.com/@itslanguage/api@v4.0.0/dist/api.min.js"></script>
+    <script src="https://unpkg.com/@itslanguage/api@v5.0.0/dist/api.min.js"></script>
     <script>
       // The api is now available through global `itslApi`.
       itslApi.createItslApi();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itslanguage/sdk",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "private": true,
   "description": "The JavaScript monorepo for ITSLanguage.",
   "engines": {

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -78,7 +78,7 @@ asume you've installed the api package with [npm]
 <html>
   <head>
     <title>Some page title</title>
-    <script src="https://unpkg.com/@itslanguage/api@v4.2.0/dist/api.min.js"></script>
+    <script src="https://unpkg.com/@itslanguage/api@v5.0.0/dist/api.min.js"></script>
     <script>
       // The api is now available through global `itslApi`.
       itslApi.createItslApi();

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itslanguage/api",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "description": "The JavaScript API SDK for ITSLanguage.",
   "author": "ITSLanguage (https://www.itslanguage.nl) <support@itslanguage.nl>",
   "contributors": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -33,5 +33,8 @@
     "autobahn": "19.7.3",
     "debug": "4.1.1",
     "event-emitter": "0.3.5"
+  },
+  "peerDependencies": {
+    "core-js": "^3.2.1"
   }
 }

--- a/packages/player/README.md
+++ b/packages/player/README.md
@@ -62,7 +62,7 @@ does not follow any best practices (i.e. use at your own risk):
 <html>
   <head>
     <title>Some page title</title>
-    <script src="https://unpkg.com/@itslanguage/player@v4.0.0/dist/player.min.js"></script>
+    <script src="https://unpkg.com/@itslanguage/player@v5.0.0/dist/player.min.js"></script>
     <script>
       // The api is now available through global `itslPlayer`.
       const audioUrl =

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -29,6 +29,7 @@
     "node": ">= 8"
   },
   "peerDependencies": {
+    "core-js": "^3.2.1",
     "@itslanguage/api": "^4.2.1"
   },
   "main": "index.js"

--- a/packages/player/package.json
+++ b/packages/player/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itslanguage/player",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "JavaScript audio player compatible with the ITSLanguage SDK.",
   "author": "ITSLanguage (https://www.itslanguage.nl) <support@itslanguage.nl>",
   "contributors": [

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -31,5 +31,8 @@
   "main": "index.js",
   "dependencies": {
     "audio-recorder-polyfill": "0.1.6"
+  },
+  "peerDependencies": {
+    "core-js": "^3.2.1"
   }
 }

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itslanguage/recorder",
-  "version": "4.2.2",
+  "version": "5.0.0",
   "description": "JavaScript Recorder based on MediaRecorder from ITSLanguage.",
   "author": "ITSLanguage (https://www.itslanguage.nl) <support@itslanguage.nl>",
   "contributors": [


### PR DESCRIPTION
Prepare the new version to be tagged.

Also one minor fix: set core-js as peer dependency.