### PR TITLE
Feat recorder plugin buffer

### DIFF
--- a/packages/recorder/index.js
+++ b/packages/recorder/index.js
@@ -4,6 +4,7 @@
 
 import MediaRecorder from 'audio-recorder-polyfill';
 import AmplitudePlugin from './plugins/amplitude';
+import BufferPlugin from './plugins/buffer';
 
 /**
  * If the recorder is imported we rely on the MediaRecorder interface. In some
@@ -148,4 +149,15 @@ export function createMediaStream() {
  */
 export function createAmplitudePlugin(options = {}) {
   return new AmplitudePlugin(options);
+}
+
+/**
+ * Factory function to create a BufferPlugin. Use the returned value of this
+ * function to pass to the plugin list of the recorder.
+ *
+ * @param {object} [options = {}] - Options to pass to the BufferPlugin.
+ * @returns {BufferPlugin} - Instance of the BufferPlugin.
+ */
+export function createBufferPlugin(options = {}) {
+  return new BufferPlugin(options);
 }

--- a/packages/recorder/index.spec.js
+++ b/packages/recorder/index.spec.js
@@ -1,5 +1,7 @@
 import MediaRecorder from 'audio-recorder-polyfill';
 import * as mediaRecorder from './index';
+import AmplitudePlugin from './plugins/amplitude';
+import BufferPlugin from './plugins/buffer';
 
 const STREAM = null;
 
@@ -112,6 +114,22 @@ describe('MediaRecorder', () => {
           );
           done();
         });
+    });
+  });
+
+  describe('createAmplitudePlugin', () => {
+    it('should return a AmplitudePlugin instance', () => {
+      const amplitudePlugin = mediaRecorder.createAmplitudePlugin();
+
+      expect(amplitudePlugin instanceof AmplitudePlugin).toBeTruthy();
+    });
+  });
+
+  describe('createBufferPlugin', () => {
+    it('should return a BufferPlugin instance', () => {
+      const bufferPlugin = mediaRecorder.createBufferPlugin();
+
+      expect(bufferPlugin instanceof BufferPlugin).toBeTruthy();
     });
   });
 });

--- a/packages/recorder/plugins/buffer/buffer.js
+++ b/packages/recorder/plugins/buffer/buffer.js
@@ -1,0 +1,229 @@
+const AudioContext =
+  window.AudioContext || /* istanbul ignore next */ window.webkitAudioContext;
+let audioContext;
+
+const BYTES_PER_SAMPLE = 2;
+
+/**
+ * Encode a Float32Array to an Uint8Array. Normalizes the audio.
+ * Heavily inspired by the wave encode function from audio-recorder-polyfill.
+ *
+ * @param {Float32Array} buffer - The buffer to encode.
+ * @returns {Uint8Array} - An Uint8Array with encoded audio.
+ */
+function encodeBuffer(buffer) {
+  const { length } = buffer;
+  const data = new Uint8Array(length * BYTES_PER_SAMPLE);
+  for (let count = 0; count < length; count += 1) {
+    const index = count * BYTES_PER_SAMPLE;
+    let sample = buffer[count];
+    if (sample > 1) {
+      sample = 1;
+    } else if (sample < -1) {
+      sample = -1;
+    }
+    sample *= 32768;
+    data[index] = sample;
+    // eslint-disable-next-line no-bitwise
+    data[index + 1] = sample >> 8;
+  }
+
+  return data;
+}
+
+/**
+ * Convert a buffer to valid WAV blob.
+ * Heavily inspired by the wave dump function from audio-recorder-polyfill.
+ *
+ * @param {Float32Array} rawBuffer - The raw audio buffer to convert.
+ * @param {number} sampleRate - Sample rate of the audio recorded.
+ * @returns {Blob} - A valid wave "blob". Ready to be played (or downloaded).
+ */
+function bufferToWAV(rawBuffer, sampleRate) {
+  const buffer = encodeBuffer(rawBuffer);
+
+  const { length } = buffer;
+  const wav = new Uint8Array(44 + length);
+  const view = new DataView(wav.buffer);
+
+  // RIFF identifier 'RIFF'
+  view.setUint32(0, 1380533830, false);
+  // file length minus RIFF identifier length and file description length
+  view.setUint32(4, 36 + length, true);
+  // RIFF type 'WAVE'
+  view.setUint32(8, 1463899717, false);
+  // format chunk identifier 'fmt '
+  view.setUint32(12, 1718449184, false);
+  // format chunk length
+  view.setUint32(16, 16, true);
+  // sample format (raw)
+  view.setUint16(20, 1, true);
+  // channel count
+  view.setUint16(22, 1, true);
+  // sample rate
+  view.setUint32(24, sampleRate, true);
+  // byte rate (sample rate * block align)
+  view.setUint32(28, sampleRate * BYTES_PER_SAMPLE, true);
+  // block align (channel count * bytes per sample)
+  view.setUint16(32, BYTES_PER_SAMPLE, true);
+  // bits per sample
+  view.setUint16(34, 8 * BYTES_PER_SAMPLE, true);
+  // data chunk identifier 'data'
+  view.setUint32(36, 1684108385, false);
+  // data chunk length
+  view.setUint32(40, length, true);
+
+  // Set the data!
+  wav.set(buffer, 44);
+
+  // Return the blob;
+  return new Blob([wav.buffer], { type: 'audio/wav' });
+}
+
+class BufferPlugin {
+  /**
+   * Event handler for the AudioProcess event. Will be called every time the
+   * buffer is full and ready to be processed.
+   *
+   * @private
+   * @param {AudioProcessingEvent} event - Audio processing event.
+   */
+  audioProcess(event) {
+    const { inputBuffer } = event;
+
+    // Add the buffer to the buffer (yes, very clear indeed);
+    const recorderData = inputBuffer.getChannelData(0);
+
+    // Shift stuff up;
+    this.buffer.copyWithin(0, recorderData.length);
+    this.buffer.set(recorderData, this.bufferSize - recorderData.length);
+  }
+
+  /**
+   * Read from the buffer, provide how many seconds to read back from it.
+   * IF passed nothing, 0 or more then there is in the buffer, the complete
+   * buffer will be returned.
+   *
+   * @param {number} secondsToRead - How many seconds to read back.
+   * @returns {Blob} - An WAVE file with the read buffer.
+   */
+  readBufferAsWAV(secondsToRead = null) {
+    let rawBuffer;
+
+    if (
+      !secondsToRead ||
+      secondsToRead >= this.secondsToBuffer ||
+      secondsToRead === 0
+    ) {
+      // In this case we return the complete buffer;
+      rawBuffer = this.buffer;
+    } else {
+      rawBuffer = this.buffer.slice(
+        this.buffer.length - secondsToRead * audioContext.sampleRate,
+      );
+    }
+
+    return bufferToWAV(rawBuffer, audioContext.sampleRate);
+  }
+
+  /**
+   * Constructor method for the BufferPlugin object.
+   *
+   * @param {MediaStreamAudioSourceNode} audioSource - Audio source to buffer.
+   * @param {number} [secondsToBuffer = 30] - Seconds to keep in buffer.
+   */
+  constructor(audioSource, secondsToBuffer = 30) {
+    // Prepare (or re-use) this file its global audioContext;
+    audioContext =
+      audioContext || /* istanbul ignore next */ new AudioContext();
+
+    /**
+     * In seconds, how large (or how long) will be buffer?
+     * @type {number}
+     */
+    this.secondsToBuffer = secondsToBuffer;
+
+    /**
+     * Total size of the buffer;
+     * @type {number}
+     */
+    this.bufferSize = secondsToBuffer * audioContext.sampleRate;
+
+    /**
+     * The buffer!
+     * @type {Float32Array}
+     */
+    this.buffer = new Float32Array(this.bufferSize);
+    this.buffer.fill(0, 0);
+
+    /**
+     * Size of the buffer that will be filled with audio data.
+     * @type {number}
+     */
+    this.scriptNodeBufferSize = 1024;
+
+    /**
+     * Audio source node.
+     * @type {MediaStreamAudioSourceNode}
+     */
+    this.audioSource = audioSource;
+
+    /**
+     * Number of input channels to work with. Using mono as default.
+     * @type {number}
+     */
+    this.inputChannels = 1;
+
+    /**
+     * Here we connect the Amplitudes ScriptProcessorNode to.
+     * @type {GainNode}
+     */
+    this.outputChannel = audioContext.createGain();
+
+    // Make sure to set `this` to the correct scope;
+    this.audioProcess = this.audioProcess.bind(this);
+
+    // Prepare a ScriptProcessorNode that will process our audio samples;
+    this.scriptProcessorNode = audioContext.createScriptProcessor(
+      this.scriptNodeBufferSize,
+      this.inputChannels,
+      1,
+    );
+
+    // Event listener to process the collected samples;
+    this.scriptProcessorNode.addEventListener(
+      'audioprocess',
+      this.audioProcess,
+    );
+
+    // Set output volume to 0 so we don't create "sound" on any speakers;
+    this.outputChannel.gain.value = 0;
+
+    // Connect the audio source to the script processor;
+    this.audioSource.connect(this.scriptProcessorNode);
+
+    // Connect the script processor to the gain node;
+    this.scriptProcessorNode.connect(this.outputChannel);
+
+    // Finally, connect the gain node the the final destination;
+    this.outputChannel.connect(audioContext.destination);
+  }
+}
+
+/**
+ * Factory function to create a BufferPlugin node.
+ *
+ * @param {MediaSource} mediaStream - MediaStream audio source, like provided
+ * from a `navigator.getUserMedia` instance. Will be converted to a
+ * MediaStreamAudioSourceNode. This can also be a file.
+ * @param {number} [secondsToBuffer] - How many seconds to keep in the buffer.
+ * @returns {BufferPlugin} - BufferPlugin node that buffers the audio of the stream.
+ */
+// eslint-disable-next-line import/prefer-default-export
+export function createBuffer(mediaStream, secondsToBuffer) {
+  // Prepare (or re-use) this file its global audioContext;
+  audioContext = audioContext || new AudioContext();
+
+  const audioSource = audioContext.createMediaStreamSource(mediaStream);
+  return new BufferPlugin(audioSource, secondsToBuffer);
+}

--- a/packages/recorder/plugins/buffer/buffer.js
+++ b/packages/recorder/plugins/buffer/buffer.js
@@ -17,9 +17,14 @@ function encodeBuffer(buffer) {
   for (let count = 0; count < length; count += 1) {
     const index = count * BYTES_PER_SAMPLE;
     let sample = buffer[count];
+
+    /* istanbul ignore if */
     if (sample > 1) {
       sample = 1;
-    } else if (sample < -1) {
+    }
+
+    /* istanbul ignore if */
+    if (sample < -1) {
       sample = -1;
     }
     sample *= 32768;

--- a/packages/recorder/plugins/buffer/index.js
+++ b/packages/recorder/plugins/buffer/index.js
@@ -1,0 +1,106 @@
+import { createBuffer } from './buffer';
+
+/**
+ * Buffer Audio.
+ * Be able to get parts of audio buffered.
+ */
+
+class BufferPlugin {
+  /**
+   * Constructor method.
+   *
+   * @param {object} options - Options to pass to the plugin.
+   * @param {boolean} options.immediateStart - Immediately start with buffering.
+   * @param {boolean} options.stopAfterRecording - Stop buffering when the
+   * recorder stops recording.
+   * @param {number} options.secondsToBuffer - Number of seconds to buffer.
+   */
+  constructor({
+    immediateStart = false,
+    stopAfterRecording = true,
+    secondsToBuffer = 30,
+  }) {
+    this.immediateStart = immediateStart;
+    this.stopAfterRecording = stopAfterRecording;
+    this.secondsToBuffer = secondsToBuffer;
+
+    this.bufferNode = null;
+    this.recorder = null;
+
+    this.startBuffering = this.startBuffering.bind(this);
+    this.stopBuffering = this.stopBuffering.bind(this);
+    this.recordingStopped = this.recordingStopped.bind(this);
+  }
+
+  /**
+   * Read the buffer and return it as WAVE file.
+   *
+   * @param secondsToRead
+   * @returns {Blob} - The requested buffer in a blob with WAVE as mimeType.
+   */
+  readBufferAsWAV(secondsToRead) {
+    const data = this.bufferNode.readBufferAsWAV(secondsToRead);
+    const event = new Event('bufferdataavailable');
+
+    if (data) {
+      event.data = data;
+
+      // Dispatch the data!
+      this.recorder.dispatchEvent(event);
+    }
+  }
+
+  /**
+   * Start buffering audio!
+   */
+  startBuffering() {
+    this.bufferNode = createBuffer(this.recorder.stream, this.secondsToBuffer);
+    this.recorder.requestBufferedData = secondsToRead => {
+      this.readBufferAsWAV(secondsToRead);
+    };
+  }
+
+  /**
+   * Stop buffering audio!
+   */
+  stopBuffering() {
+    this.bufferNode = null;
+    delete this.recorder.requestBufferedData;
+  }
+
+  /**
+   * Handler for the recorder, this gets executed as soon as the recorder stops
+   * recording. Based on the options it will stop buffering.
+   */
+  recordingStopped() {
+    if (this.stopAfterRecording) {
+      this.stopBuffering();
+    }
+  }
+
+  /**
+   * Start the plugin.
+   */
+  startPlugin() {
+    if (this.immediateStart) {
+      this.startBuffering();
+    }
+
+    this.recorder.addEventListener('start', this.startBuffering);
+    this.recorder.addEventListener('stop', this.recordingStopped);
+  }
+
+  /**
+   * This function gets called from itslanguage recorder side. It will pass
+   * the recorder to it so we can use it.
+   *
+   * @param {MediaRecorder} recorder - Recorder for which this plugin needs to be
+   * active on.
+   */
+  applyPlugin(recorder) {
+    this.recorder = recorder;
+    this.startPlugin();
+  }
+}
+
+export default BufferPlugin;

--- a/packages/recorder/plugins/buffer/index.js
+++ b/packages/recorder/plugins/buffer/index.js
@@ -28,7 +28,6 @@ class BufferPlugin {
     this.recorder = null;
 
     this.startBuffering = this.startBuffering.bind(this);
-    this.stopBuffering = this.stopBuffering.bind(this);
     this.recordingStopped = this.recordingStopped.bind(this);
   }
 

--- a/packages/recorder/plugins/buffer/index.js
+++ b/packages/recorder/plugins/buffer/index.js
@@ -18,7 +18,7 @@ class BufferPlugin {
   constructor({
     immediateStart = false,
     stopAfterRecording = true,
-    secondsToBuffer = 30,
+    secondsToBuffer,
   }) {
     this.immediateStart = immediateStart;
     this.stopAfterRecording = stopAfterRecording;

--- a/packages/recorder/plugins/buffer/index.spec.js
+++ b/packages/recorder/plugins/buffer/index.spec.js
@@ -1,0 +1,94 @@
+import {
+  createBufferPlugin,
+  createMediaStream,
+  createRecorder,
+} from '../../index';
+
+function wait(seconds = 2) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, seconds * 1000);
+  });
+}
+
+describe('BufferPlugin', () => {
+  it('should start the plugin immediately', async () => {
+    const stream = await createMediaStream();
+    const bufferPlugin = createBufferPlugin({
+      immediateStart: true,
+    });
+    const startBufferingSpy = spyOn(bufferPlugin, 'startBuffering');
+    const recorder = createRecorder(stream, [bufferPlugin]);
+
+    expect(startBufferingSpy).toHaveBeenCalledTimes(1);
+    recorder.start();
+    recorder.stop();
+
+    expect(startBufferingSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('should default to stop the plugin after recording ends', async () => {
+    const stream = await createMediaStream();
+    const bufferPlugin = createBufferPlugin();
+    const recorder = createRecorder(stream, [bufferPlugin]);
+
+    const stopBufferingSpy = spyOn(bufferPlugin, 'stopBuffering');
+
+    recorder.start();
+    await wait(1); // Record for 1 second;
+    recorder.stop();
+
+    await wait(2);
+
+    expect(stopBufferingSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not stop the plugin after recording ends', async () => {
+    const stream = await createMediaStream();
+    const bufferPlugin = createBufferPlugin({
+      stopAfterRecording: false,
+    });
+    const stopBufferingSpy = spyOn(bufferPlugin, 'stopBuffering');
+
+    const recorder = createRecorder(stream, [bufferPlugin]);
+
+    recorder.start();
+    await wait(1); // Record for 1 second;
+    recorder.stop();
+
+    await wait(2);
+
+    expect(stopBufferingSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('should dispatch an event when requesting buffered data', async done => {
+    const stream = await createMediaStream();
+    const bufferPlugin = createBufferPlugin({
+      immediateStart: true,
+    });
+
+    const recorder = createRecorder(stream, [bufferPlugin]);
+
+    recorder.addEventListener('bufferdataavailable', () => {
+      done();
+    });
+
+    recorder.requestBufferedData(1);
+    await wait(2);
+  });
+
+  it('should not dispatch an event when requesting buffered gave no data', async () => {
+    const stream = await createMediaStream();
+    const bufferPlugin = createBufferPlugin({
+      immediateStart: true,
+    });
+    const recorder = createRecorder(stream, [bufferPlugin]);
+    const dispatchEventSpy = spyOn(recorder, 'dispatchEvent');
+
+    spyOn(bufferPlugin.bufferNode, 'readBufferAsWAV').and.returnValue(null);
+    bufferPlugin.readBufferAsWAV(1);
+
+    expect(dispatchEventSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/recorder/plugins/buffer/index.spec.js
+++ b/packages/recorder/plugins/buffer/index.spec.js
@@ -91,4 +91,43 @@ describe('BufferPlugin', () => {
 
     expect(dispatchEventSpy).toHaveBeenCalledTimes(0);
   });
+
+  it('should return 3 seconds of the buffer', async done => {
+    const stream = await createMediaStream();
+    const bufferPlugin = createBufferPlugin({
+      immediateStart: true,
+    });
+    const recorder = createRecorder(stream, [bufferPlugin]);
+
+    recorder.addEventListener('bufferdataavailable', async ({ data }) => {
+      const audio = new Audio(URL.createObjectURL(data));
+      await wait(2);
+
+      expect(audio.duration).toBe(3);
+      done();
+    });
+
+    recorder.requestBufferedData(3);
+    await wait(2);
+  });
+
+  it('should return everything in the buffer', async done => {
+    const stream = await createMediaStream();
+    const bufferPlugin = createBufferPlugin({
+      immediateStart: true,
+      secondsToBuffer: 30,
+    });
+    const recorder = createRecorder(stream, [bufferPlugin]);
+
+    recorder.addEventListener('bufferdataavailable', async ({ data }) => {
+      const audio = new Audio(URL.createObjectURL(data));
+      await wait(2);
+
+      expect(audio.duration).toBe(30);
+      done();
+    });
+
+    recorder.requestBufferedData();
+    await wait(2);
+  });
 });


### PR DESCRIPTION
Example code will be in the next PR.

This introduces the BufferPlugin. Enable it on the recorder to be able to lookback.

Use `secondsToBuffer` to set the length to buffer. Use `requestBufferedData()` to trigger getting the data, and optionally pass the number of seconds you want to that function. Finally, add an `bufferdataavailable` listener to the recorder to get the buffered data.