### PR TITLE
Issue #365: Progress getById groupId

### DIFF
--- a/packages/api/progress/index.js
+++ b/packages/api/progress/index.js
@@ -28,9 +28,10 @@ const url = '/categories';
 // eslint-disable-next-line import/prefer-default-export
 export function getById(id, groups = [], role = '') {
   let filters = '';
+  const hasGroups = Array.isArray(groups) && groups.length;
   const searchParams = new URLSearchParams();
 
-  if (groups.length) {
+  if (hasGroups) {
     // If we have groups, add them to the searchParams!
     groups.forEach(group => {
       searchParams.append('group', group);
@@ -42,7 +43,7 @@ export function getById(id, groups = [], role = '') {
     searchParams.append('role', role);
   }
 
-  if (groups.length || role) {
+  if (hasGroups || role) {
     // If we had groups or roles, construct a querystring based on searchParams.
     filters = `?${searchParams.toString()}`;
   }

--- a/packages/api/progress/index.spec.js
+++ b/packages/api/progress/index.spec.js
@@ -111,5 +111,20 @@ describe('progress', () => {
         })
         .catch(done.fail);
     });
+
+    it('should not fail if the groups parameter is not an array', done => {
+      const authorisedRequestSpy = spyOn(communication, 'authorisedRequest');
+      authorisedRequestSpy.and.returnValue(Promise.resolve({ id: 'c4t' }));
+
+      progress
+        .getById('c4t', 'not-an-array')
+        .then(() => {
+          const getRequest = authorisedRequestSpy.calls.mostRecent();
+
+          expect(getRequest.args).toEqual(['GET', '/categories/c4t/progress']);
+          done();
+        })
+        .catch(done.fail);
+    });
   });
 });


### PR DESCRIPTION
This fix adds an additional check to make sure that `groups` param is an array
Tests added (but have not been ran)

I didn't have the time to figure out how to run the test spec file through a transpire before running it through tests, and node does not support modules out of the box.

Also, it's not the greatest idea to silently ignore the fact that the api expects `groups` as an array if given a string or something else, so the test spec should change.