### PR TITLE
Make it possible to override the event

### DIFF
--- a/packages/recorder/plugins/buffer/index.js
+++ b/packages/recorder/plugins/buffer/index.js
@@ -14,15 +14,21 @@ class BufferPlugin {
    * @param {boolean} options.stopAfterRecording - Stop buffering when the
    * recorder stops recording.
    * @param {number} options.secondsToBuffer - Number of seconds to buffer.
+   * @param {string} [options.eventToDispatch=bufferdatavailable] - The event to
+   * use to dispatch buffered audio. By default we will use
+   * `bufferdataavailable` but it could be, as example, convenient to use the
+   * regular `dataavailable` event.
    */
   constructor({
     immediateStart = false,
     stopAfterRecording = true,
     secondsToBuffer,
+    eventToDispatch = 'bufferdataavailable',
   }) {
     this.immediateStart = immediateStart;
     this.stopAfterRecording = stopAfterRecording;
     this.secondsToBuffer = secondsToBuffer;
+    this.eventToDispatch = eventToDispatch;
 
     this.bufferNode = null;
     this.recorder = null;
@@ -39,7 +45,7 @@ class BufferPlugin {
    */
   readBufferAsWAV(secondsToRead) {
     const data = this.bufferNode.readBufferAsWAV(secondsToRead);
-    const event = new Event('bufferdataavailable');
+    const event = new Event(this.eventToDispatch);
 
     if (data) {
       event.data = data;

--- a/packages/recorder/plugins/buffer/index.spec.js
+++ b/packages/recorder/plugins/buffer/index.spec.js
@@ -130,4 +130,21 @@ describe('BufferPlugin', () => {
     recorder.requestBufferedData();
     await wait(2);
   });
+
+  it('should dispatch a custsom event when requesting buffered data', async done => {
+    const stream = await createMediaStream();
+    const bufferPlugin = createBufferPlugin({
+      immediateStart: true,
+      eventToDispatch: 'blablabla',
+    });
+
+    const recorder = createRecorder(stream, [bufferPlugin]);
+
+    recorder.addEventListener('blablabla', () => {
+      done();
+    });
+
+    recorder.requestBufferedData(1);
+    await wait(2);
+  });
 });


### PR DESCRIPTION
In stead of dispatching an `bufferdataavailable` event, allow overriding te event.

This could be convenient to use the `dataavailable` event, which is needed to use for the Feedback API.