### PR TITLE
Refactor some async tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,14 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ### Changed
 
 - `recorder`
+
   - Updated the recorder readme file to be more accurate.
+
+### Fixed
+
+- `api`
+  - Fix the stability of the test by taking the asynchronous approach that was
+    used into account.
 
 ## [v5.1.0] - 2019-09-27
 


### PR DESCRIPTION
It seems the async/await way of doing the test causes them to sometimes
fail because some other test messes up. Messes up is due to using some
variables that get overridden multiple times making them unreliable.

Moved this to a more solid approach and put it all in a setup function.

This should make the tets more reliable and less prone to "randomly" fail.