### PR TITLE
Fix passing group id as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
   - Really cleanup some event listeners on the recorder after they have been
     used for streaming audio to the backend.
   - TypeError raised by makeWebsocketCall.
+  - Allow to pass groups as a string (next to an array) and disallow other
+    types. This is for the getById function of the Progress API.
 
 ### Changed
 

--- a/packages/api/progress/index.js
+++ b/packages/api/progress/index.js
@@ -20,7 +20,8 @@ const url = '/categories';
  * is passed it will return progress for all users from that group.
  *
  * @param {string} id - The category id.
- * @param {Array} [groups=[]] - The id's of the groups to get progress on.
+ * @param {Array|string} [groups=[]] - The id's or id  of the groups to get
+ * progress on.
  * @param {string} [role=''] - The id of the role that a user should be in.
  *
  * @returns {Promise} - The promise for the organisation.
@@ -29,10 +30,17 @@ const url = '/categories';
 export function getById(id, groups = [], role = '') {
   let filters = '';
   const searchParams = new URLSearchParams();
+  let groupIds = [];
 
-  if (groups.length) {
+  if (typeof groups === 'string') {
+    groupIds = groups.split(); // convert 'STRING' to ['STRING'];
+  } else if (Array.isArray(groups)) {
+    groupIds = groups;
+  }
+
+  if (groupIds.length > 0) {
     // If we have groups, add them to the searchParams!
-    groups.forEach(group => {
+    groupIds.forEach(group => {
       searchParams.append('group', group);
     });
   }
@@ -42,7 +50,7 @@ export function getById(id, groups = [], role = '') {
     searchParams.append('role', role);
   }
 
-  if (groups.length || role) {
+  if (groupIds.length > 0 || role) {
     // If we had groups or roles, construct a querystring based on searchParams.
     filters = `?${searchParams.toString()}`;
   }

--- a/packages/api/progress/index.spec.js
+++ b/packages/api/progress/index.spec.js
@@ -111,5 +111,56 @@ describe('progress', () => {
         })
         .catch(done.fail);
     });
+
+    it('should allow passing groups a string in stead of array', done => {
+      const authorisedRequestSpy = spyOn(communication, 'authorisedRequest');
+      authorisedRequestSpy.and.returnValue(Promise.resolve({ id: 'c4t' }));
+
+      progress
+        .getById('c4t', 'group', 'GROUP_ROLE')
+        .then(() => {
+          const getRequest = authorisedRequestSpy.calls.mostRecent();
+
+          expect(getRequest.args).toEqual([
+            'GET',
+            '/categories/c4t/progress?group=group&role=GROUP_ROLE',
+          ]);
+          done();
+        })
+        .catch(done.fail);
+    });
+
+    it('should not get a group by id when groups is neither string or array', done => {
+      const authorisedRequestSpy = spyOn(communication, 'authorisedRequest');
+      authorisedRequestSpy.and.returnValue(Promise.resolve({ id: 'c4t' }));
+
+      progress
+        .getById('c4t', null)
+        .then(() => {
+          const getRequest = authorisedRequestSpy.calls.mostRecent();
+
+          expect(getRequest.args).toEqual(['GET', '/categories/c4t/progress']);
+          done();
+        })
+        .catch(done.fail);
+    });
+
+    it('should only get progress by id for a role when no valid group is passed', done => {
+      const authorisedRequestSpy = spyOn(communication, 'authorisedRequest');
+      authorisedRequestSpy.and.returnValue(Promise.resolve({ id: 'c4t' }));
+
+      progress
+        .getById('c4t', null, 'SOME_ROLE')
+        .then(() => {
+          const getRequest = authorisedRequestSpy.calls.mostRecent();
+
+          expect(getRequest.args).toEqual([
+            'GET',
+            '/categories/c4t/progress?role=SOME_ROLE',
+          ]);
+          done();
+        })
+        .catch(done.fail);
+    });
   });
 });


### PR DESCRIPTION
Fix the unclear message "groups.forEach is not a function" by allowing both an array and string as input for the Progress.getById api. If an invalid value is passed it will be ignored.

This also allows to getById by just passing a role and no group more conveniently.

Fix #365 
Close #368 