### PR TITLE
Improve audio stream for feedback API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- `api`
+  - When stopping the recorder if no audio was send, make sure to clean up and
+    close the websocket connection.
+
 ### Changed
 
 - `api`
+  - Do not auto reconnect the websocket connection by default.
   - Add closing of the WebSocket connection to the finally handler
     in stead of doing it in both the then and catch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
   - Do not auto reconnect the websocket connection by default.
   - Add closing of the WebSocket connection to the finally handler
     in stead of doing it in both the then and catch.
+  - Check the size of the audio blob to send. If it seems to only have a header
+    it wont sent it (true for wave). Any other mimeType will check for size > 0.
 
 ## [v5.4.1] - 2020-02-11
 

--- a/packages/api/communication/websocket.js
+++ b/packages/api/communication/websocket.js
@@ -60,6 +60,7 @@ function establishNewBundesbahn() {
       details: {
         ticket: settings.authorizationToken,
       },
+      max_retries: 0,
       onchallenge: handleWebsocketAuthorisationChallenge,
     });
 

--- a/packages/api/utils/audio-over-socket.spec.js
+++ b/packages/api/utils/audio-over-socket.spec.js
@@ -11,6 +11,14 @@ import broadcaster from '../broadcaster';
 
 const rpcName = 'rpcName';
 
+function wait(seconds = 2) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, seconds * 1000);
+  });
+}
+
 function setupStubsSimple() {
   const recorderStub = jasmine.createSpyObj('Recorder', [
     'addEventListener',
@@ -139,6 +147,8 @@ describe('Audio Over socket', () => {
 
     it('should stream audio to the backend', async () => {
       const { recorderStub } = setupStubs();
+      let dataavailableCallback = null;
+      let stopCallback = null;
       const data = {
         data: new Blob(['Knees weak, arms are heavy.'], { type: 'text/plain' }),
       };
@@ -149,32 +159,47 @@ describe('Audio Over socket', () => {
       const intArray = Array.from(new Uint8Array(arrayBuffer));
 
       recorderStub.addEventListener.and.callFake((event, callback) => {
-        // Pretend as if the event has been fired and thus call the callback.
-        callback(data);
+        switch (event) {
+          case 'dataavailable':
+            dataavailableCallback = callback;
+            break;
+          case 'stop':
+            stopCallback = callback;
+            break;
+          default:
+            break;
+        }
       });
 
       const result = await aos.registerStreamForRecorder(recorderStub, rpcName);
-
       const detailsSpy = jasmine.createSpyObj('details', ['progress']);
-      await result.callback([], {}, detailsSpy);
+
+      result.callback([], {}, detailsSpy);
+
+      dataavailableCallback(data);
+
+      await wait(1); // Wait a second before sending stop;
+      stopCallback();
+
+      // Add a wait to make sure the events are properly processed.
+      await wait();
 
       expect(detailsSpy.progress).toHaveBeenCalledWith([intArray]);
     });
 
     it('should not stream audio if the progress function does not exist', async () => {
       const { recorderStub } = setupStubs();
+      const data = {
+        data: new Blob(['Knees weak, arms are heavy.'], { type: 'text/plain' }),
+      };
 
       recorderStub.addEventListener.and.callFake((event, callback) => {
-        // Pretend as if the event has been fired and thus call the callback.
-        callback({
-          data: new Blob(['Knees weak, arms are heavy.'], {
-            type: 'text/plain',
-          }),
-        });
+        if (event === 'dataavailable') {
+          callback(data);
+        }
       });
 
       const result = await aos.registerStreamForRecorder(recorderStub, rpcName);
-
       await expectAsync(result.callback([], {}, {})).toBeRejectedWith(
         'no progress function registered',
       );
@@ -203,22 +228,35 @@ describe('Audio Over socket', () => {
 
       const result = await aos.registerStreamForRecorder(recorderStub, rpcName);
       const detailsSpy = jasmine.createSpyObj('details', ['progress']);
-      result.callback([], {}, detailsSpy);
+      const resultCB = result.callback([], {}, detailsSpy);
 
       dataavailableCallback(blob);
 
-      // We need to wait a bit before we can send the rest.
-      setTimeout(async () => {
-        // Send the stop event
-        stopCallback();
+      await wait(1); // Wait a second before sending stop;
+      stopCallback();
 
-        // Send the final chunk!
-        dataavailableCallback(blob);
-      }, 1000);
+      await wait(1); // Wait a second before sending stop;
+      dataavailableCallback(blob);
 
-      await result.callback([], {}, detailsSpy);
+      await expectAsync(resultCB).toBeResolved();
+    });
 
-      expect(detailsSpy.progress).toHaveBeenCalledTimes(2);
+    it('should resolve if stopped without sending data', async () => {
+      const { recorderStub } = setupStubs();
+      let stopCallback = null;
+
+      recorderStub.addEventListener.and.callFake((event, callback) => {
+        if (event === 'stop') {
+          stopCallback = callback;
+        }
+      });
+
+      const result = await aos.registerStreamForRecorder(recorderStub, rpcName);
+      const detailsSpy = jasmine.createSpyObj('details', ['progress']);
+      const resultCB = result.callback([], {}, detailsSpy);
+
+      stopCallback();
+      await expectAsync(resultCB).toBeResolved();
     });
   });
 

--- a/packages/api/utils/index.js
+++ b/packages/api/utils/index.js
@@ -43,3 +43,26 @@ export function asyncBlobToArrayBuffer(blob) {
     fileReader.readAsArrayBuffer(blob);
   });
 }
+
+/**
+ * A Cheap test to check if the provided audio file has just the header, or that
+ * it can be assumed to be "audio". The mimeType is used to do make a best
+ * guess. Currently only WAV is supported.
+ *
+ * @param {number} filesize - Size of the file to check.
+ * @param {string} mimeType - Type of the provided blob.
+ * @returns {boolean} - Has audio.
+ */
+export function checkAudioIsNotEmpty(filesize, mimeType) {
+  let result;
+
+  switch (mimeType) {
+    case 'audio/wav':
+      result = filesize > 44;
+      break;
+    default:
+      result = filesize > 0;
+  }
+
+  return result;
+}

--- a/packages/api/utils/index.spec.js
+++ b/packages/api/utils/index.spec.js
@@ -48,3 +48,25 @@ describe('asyncBlobToArrayBuffer', () => {
       .catch(done.fail);
   });
 });
+
+describe('checkAudioIsNotEmpty', () => {
+  it('should return false if size is 0', () => {
+    expect(utils.checkAudioIsNotEmpty(0, '')).toBe(false);
+  });
+
+  it('should return true if size is > 0', () => {
+    expect(utils.checkAudioIsNotEmpty(1, '')).toBe(true);
+  });
+
+  it('should return false if size is 0 and mimetype is audio/wav', () => {
+    expect(utils.checkAudioIsNotEmpty(0, 'audio/wav')).toBe(false);
+  });
+
+  it('should return false if size is 44 and mimetype is audio/wav', () => {
+    expect(utils.checkAudioIsNotEmpty(44, 'audio/wav')).toBe(false);
+  });
+
+  it('should return true if size is > 44 and mimetype is audio/wav', () => {
+    expect(utils.checkAudioIsNotEmpty(45, 'audio/wav')).toBe(true);
+  });
+});


### PR DESCRIPTION
- Make it possible to resolve the autobahn deferred when stopping the recorder when no audio was sent;
- Added a cheap test that tries to look at the blob that is send to the backend. In some cases it will not be tried to send;
- Don't assume a reconnect;

Fixes #386 