### PR TITLE
fix: do not remove the onclose handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- `api`
+  - Improved the connection and more specifically the disconnection. It will
+    show an error if it was not closed normally. Previously the reason for
+    closure was swallowed and not visible for the user.
+
 ## [v5.6.0] - 2020-04-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+## [v5.6.1] - 2020-07-06
+
 ### Changed
 
 - `api`
@@ -295,7 +297,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Improve README.md documentation.
 - Changed the getUserAuth and getOAuth2Token to use the new API auth functions.
 
-[unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v5.6.0...HEAD
+[unreleased]: https://github.com/itslanguage/itslanguage-js/compare/v5.6.1...HEAD
+[v5.6.1]: https://github.com/itslanguage/itslanguage-js/compare/v5.6.0...v5.6.1
 [v5.6.0]: https://github.com/itslanguage/itslanguage-js/compare/v5.5.1...v5.6.0
 [v5.5.1]: https://github.com/itslanguage/itslanguage-js/compare/v5.5.0...v5.5.1
 [v5.5.0]: https://github.com/itslanguage/itslanguage-js/compare/v5.4.1...v5.5.0

--- a/packages/api/communication/websocket.js
+++ b/packages/api/communication/websocket.js
@@ -81,8 +81,6 @@ function establishNewBundesbahn() {
     // Connection got established; lets us it.
     bahn.onopen = () => {
       log('Successfully established a websocket connection.');
-      // Remove the `onclose` handler as it is no longer of interest to us.
-      delete bahn.onclose;
       resolve(bahn);
     };
 

--- a/packages/api/communication/websocket.js
+++ b/packages/api/communication/websocket.js
@@ -64,18 +64,19 @@ function establishNewBundesbahn() {
       onchallenge: handleWebsocketAuthorisationChallenge,
     });
 
-    // `autobahn.Connection` calls its `onclose` method, if it exists, when it
-    // was not able to open a connection.
-    bahn.onclose = (/* reason, details */) => {
-      // When the connection failed to open a reason is given with some details.
-      // Sadly these are very un-descriptive. Therefore hint/warn the developer
-      // about potential erroneous settings or to contact us.
-      const message =
-        'The connection is erroneous; check if all required ' +
-        'settings have been injected using the ' +
-        '`updateSettings()` function. If the problem persists ' +
-        'please post a issue on our GitHub repository.';
-      reject(message);
+    // The connection close callback is fired when the connection has been
+    // closed explicitly, was lost or could not be established in the first
+    // place. For more information on the connection callbacks go to
+    // https://github.com/crossbario/autobahn-js/blob/master/doc/reference.md#connection-callbacks
+    bahn.onclose = (reason, details) => {
+      if (reason === 'closed' && details.reason === 'wamp.close.normal') {
+        // A normal disconnect! No need to error out here;
+        resolve(reason);
+      } else {
+        // Several errors might be true here
+        // closed, lost, unreachable or unsupported
+        reject(reason);
+      }
     };
 
     // Connection got established; lets us it.

--- a/packages/api/communication/websocket.spec.js
+++ b/packages/api/communication/websocket.spec.js
@@ -32,6 +32,13 @@ function prepareConnectionStubs() {
     this.onopen();
   });
 
+  connectionCloseSpy.and.callFake(function() {
+    const reason = 'closed';
+    const message = 'wamp.close.normal';
+
+    this.onclose(reason, { reason: message });
+  });
+
   return {
     connectionOpenSpy,
     connectionCloseSpy,
@@ -119,11 +126,7 @@ describe('Websocket API', () => {
 
     it('should reject if the connection could not be established', async () => {
       await expectAsync(websocket.openWebsocketConnection()).toBeRejectedWith(
-        'The connection is erroneous; check if all ' +
-          'required settings have been injected using ' +
-          'the `updateSettings()` function. If the ' +
-          'problem persists please post a issue on our ' +
-          'GitHub repository.',
+        'unreachable',
       );
 
       // There shouldn't be a reference to the erroneos connection. We can

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itslanguage/api",
-  "version": "5.5.1",
+  "version": "5.6.1",
   "description": "The JavaScript API SDK for ITSLanguage.",
   "author": "ITSLanguage (https://www.itslanguage.nl) <support@itslanguage.nl>",
   "contributors": [


### PR DESCRIPTION
- Do not remove the onclose handler
- use the reason when the connection is closed
- prepare new patch version (v5.6.1)

Fixes #397 